### PR TITLE
feat/add_docker_image_for_ZAD_actions

### DIFF
--- a/.github/workflows/zad.yml
+++ b/.github/workflows/zad.yml
@@ -27,12 +27,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
+          tags: ghcr.io/rijksictgilde/toetsingskader-archiefwet:pr-${{ github.event.number }}
 
   deploy-preview:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
@@ -52,7 +55,7 @@ jobs:
           project-id: toets-hn7
           deployment-name: pr-${{ github.event.pull_request.number }}
           component: web
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
+          image: ghcr.io/rijksictgilde/toetsingskader-archiefwet:pr-${{ github.event.number }}
           clone-from: production
 
   cleanup-preview:
@@ -90,4 +93,4 @@ jobs:
           project-id: toets-hn7
           deployment-name: production
           component: web
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
+          image: ghcr.io/rijksictgilde/toetsingskader-archiefwet:pr-${{ github.event.number }}

--- a/.github/workflows/zad.yml
+++ b/.github/workflows/zad.yml
@@ -8,11 +8,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE: ghcr.io/rijksictgilde/toetsingskader-archiefwet
 
 jobs:
   build:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,18 +27,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lowercase image name
-        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+      - name: Determine image tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "TAG=main-${{ github.sha }}" >> "$GITHUB_ENV"
+          else
+            echo "TAG=pr-${{ github.event.number }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ghcr.io/rijksictgilde/toetsingskader-archiefwet:pr-${{ github.event.number }}
+          tags: ${{ env.IMAGE }}:${{ env.TAG }}
 
   deploy-preview:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.user.type != 'Bot'
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -55,11 +60,11 @@ jobs:
           project-id: toets-hn7
           deployment-name: pr-${{ github.event.pull_request.number }}
           component: web
-          image: ghcr.io/rijksictgilde/toetsingskader-archiefwet:pr-${{ github.event.number }}
+          image: ${{ env.IMAGE }}:pr-${{ github.event.number }}
           clone-from: production
 
   cleanup-preview:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       deployments: write
@@ -93,4 +98,4 @@ jobs:
           project-id: toets-hn7
           deployment-name: production
           component: web
-          image: ghcr.io/rijksictgilde/toetsingskader-archiefwet:pr-${{ github.event.number }}
+          image: ${{ env.IMAGE }}:main-${{ github.sha }}

--- a/.github/workflows/zad.yml
+++ b/.github/workflows/zad.yml
@@ -81,9 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    environment:
-      name: production
-      url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Deploy to ZAD
         id: deploy

--- a/.github/workflows/zad.yml
+++ b/.github/workflows/zad.yml
@@ -1,0 +1,93 @@
+name: Deploy to ZAD
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+            type=sha,event=push
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+  deploy-preview:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pr${{ github.event.pull_request.number }}
+    steps:
+      - uses: RijksICTGilde/zad-actions/deploy@v3
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: toets-hn7
+          deployment-name: pr${{ github.event.pull_request.number }}
+          component: web
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+          clone-from: production
+
+  cleanup-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      packages: write
+    steps:
+      - uses: RijksICTGilde/zad-actions/cleanup@v3
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: toets-hn7
+          deployment-name: pr${{ github.event.pull_request.number }}
+          delete-github-env: true
+          delete-github-deployments: true
+          delete-container: true
+          container-org: ${{ github.repository_owner }}
+          container-name: ${{ github.event.repository.name }}
+          container-tag: pr-${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-admin-token: ${{ secrets.GITHUB_ADMIN_TOKEN }}
+
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: production
+    steps:
+      - uses: RijksICTGilde/zad-actions/deploy@v3
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY }}
+          project-id: toets-hn7
+          deployment-name: production
+          component: web
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}

--- a/.github/workflows/zad.yml
+++ b/.github/workflows/zad.yml
@@ -16,44 +16,43 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: write # push container images to ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/login-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=pr
-            type=sha,event=push
-
-      - uses: docker/build-push-action@v6
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
 
   deploy-preview:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
     needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
-      name: pr${{ github.event.pull_request.number }}
+      name: pr-${{ github.event.pull_request.number }}
+      url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: RijksICTGilde/zad-actions/deploy@v3
+      - name: Deploy to ZAD
+        id: deploy
+        uses: RijksICTGilde/zad-actions/deploy@v3
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: toets-hn7
-          deployment-name: pr${{ github.event.pull_request.number }}
+          deployment-name: pr-${{ github.event.pull_request.number }}
           component: web
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}
           clone-from: production
 
   cleanup-preview:
@@ -61,33 +60,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       deployments: write
-      packages: write
+      packages: delete # delete container images from ghcr.io
     steps:
       - uses: RijksICTGilde/zad-actions/cleanup@v3
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: toets-hn7
-          deployment-name: pr${{ github.event.pull_request.number }}
-          delete-github-env: true
-          delete-github-deployments: true
-          delete-container: true
+          deployment-name: pr-${{ github.event.pull_request.number }}
+          delete-github-env: 'true'
+          delete-github-deployments: 'true'
+          delete-container: 'true'
           container-org: ${{ github.repository_owner }}
           container-name: ${{ github.event.repository.name }}
-          container-tag: pr-${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          container-tag: pr-${{ github.event.number }}
           github-admin-token: ${{ secrets.GITHUB_ADMIN_TOKEN }}
 
   deploy-production:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
     needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: production
+      url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: RijksICTGilde/zad-actions/deploy@v3
+      - name: Deploy to ZAD
+        id: deploy
+        uses: RijksICTGilde/zad-actions/deploy@v3
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: toets-hn7
           deployment-name: production
           component: web
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.number }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 ARG BASE_PATH=/
 RUN hugo --minify --baseURL "${BASE_PATH}"
 
-FROM ghcr.io/rijksictgilde/nginx-base:latest
+FROM ghcr.io/rijksictgilde/nginx-base:2026.03.1
 COPY --from=build /src/public/ /usr/share/nginx/html/
 COPY nginx.default.conf.template /etc/nginx/templates/default.conf.template
 ENV BASE_PATH=/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.24-alpine AS build
+RUN apk add --no-cache git hugo
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN hugo mod get
+COPY . .
+ARG BASE_PATH=/
+RUN hugo --minify --baseURL "${BASE_PATH}"
+
+FROM ghcr.io/rijksictgilde/nginx-base:latest
+COPY --from=build /src/public/ /usr/share/nginx/html/
+COPY nginx.default.conf.template /etc/nginx/templates/default.conf.template
+ENV BASE_PATH=/
+EXPOSE 8080

--- a/nginx.default.conf.template
+++ b/nginx.default.conf.template
@@ -1,0 +1,12 @@
+server {
+    listen 8080;
+    server_name localhost;
+    absolute_redirect off;
+
+    location ${BASE_PATH} {
+        alias /usr/share/nginx/html/;
+        try_files $uri $uri/ ${BASE_PATH}/index.html;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+}


### PR DESCRIPTION
Samenvatting

  - Dockerfile toegevoegd: multi-stage build met Hugo + ghcr.io/rijksictgilde/nginx-base
  - Nginx config template met dynamisch BASE_PATH voor ZAD
  - GitHub Actions workflow voor automatische deployment naar ZAD (project toets-hn7)

Wat doet de workflow?

  - PR geopend/updated → bouwt container image, deployt preview naar ZAD
  - PR gesloten → ruimt ZAD deployment en container image op
  - Push naar main → bouwt container image, deployt naar production op ZAD

Vereiste secrets

  - ZAD_API_KEY (repo secret) ✅
  - GITHUB_ADMIN_TOKEN (repo secret, optioneel voor PR cleanup)


Ik heb niet de rechten om de volgende Github Setting aan te passen:
<img width="827" height="404" alt="Screenshot 2026-03-25 at 09 55 09" src="https://github.com/user-attachments/assets/517b540a-fa54-456b-8a40-268a90c7a011" />

