### PR TITLE
fix: htmltest robuust tegen externe overheidssites

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,1 +1,7 @@
 DirectoryPath: .htmltest/public
+# Trage overheidssites krijgen ruimer de tijd dan de default (15s).
+ExternalTimeout: 45
+IgnoreURLs:
+  # Serveert een incomplete certificaatketen; client-side niet op te lossen,
+  # htmltest faalt er hard op terwijl de links in de browser gewoon werken.
+  - '^https://zoek\.officielebekendmakingen\.nl/'


### PR DESCRIPTION
## Wat

`.htmltest.yml`: `ExternalTimeout` van 15s (default) naar 45s, en `zoek.officielebekendmakingen.nl` op de ignore-lijst.

## Waarom

De Test-workflow op `main` faalt sinds vandaag op externe links (zie de run van 07:20 / 09:21):

- `zoek.officielebekendmakingen.nl` serveert een **incomplete certificaatketen** — in de browser werkt het (die repareert de keten zelf), maar htmltest faalt er hard op. Client-side niet op te lossen → ignore.
- `nationaalarchief.nl` is regelmatig trager dan de default timeout van 15s → ruimere timeout, blijft wél gecheckt.

Deze links stonden al op de site (referenties bij norm 1); de fout is omgevingsgedreven, niet door een content-wijziging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)