### PR TITLE
Fix/UI kleine fixes

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -23,15 +23,10 @@
   padding-block-end: 0.5rem;
 }
 
-/* Onderscheid thema vs voorschrift via de accentkleur (niet via eigen
-   groottes — typografie komt uit het thema): thema (h3) = blauw; voorschrift
-   en criteria/indicatoren = thema-standaardkleur (donker). */
-.norm h3 {
-  color: var(--color-primary);
-}
-
-/* Scheidingslijn boven elk voorschrift, behalve het eerste van een thema. */
+/* Normuitleg (h2) en thema (h3) staan in de thema-standaardkleur (donker);
+   het Voorschrift is de blauwe accent-kop. */
 .norm h4[id^="voorschrift"] {
+  color: var(--color-primary);
   padding-block-start: 0.75rem;
   border-block-start: 1px solid var(--color-border);
 }
@@ -41,9 +36,14 @@
   padding-block-start: 0;
 }
 
-/* Criteria en Indicatoren springen in t.o.v. Voorschrift — zowel de kop als
-   de eropvolgende inhoud (lijst of "Niet van toepassing"). margin (niet
-   padding) zodat lijst-bullets op hun plek blijven. */
+/* Criteria en Indicatoren: sub-items van het voorschrift — iets kleiner en
+   ingesprongen (zowel de kop als de eropvolgende inhoud; margin i.p.v.
+   padding zodat lijst-bullets op hun plek blijven). */
+.norm h4[id^="criteria"],
+.norm h4[id^="indicatoren"] {
+  font-size: 1.15rem;
+}
+
 .norm h4[id^="criteria"],
 .norm h4[id^="indicatoren"],
 .norm h4[id^="criteria"] + *,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -57,3 +57,44 @@
 .norm a.ref-term:hover {
   color: inherit;
 }
+
+/* Inklapbare Toelichting (standaard dicht). Summary oogt als de sectie-h2
+   (1.75rem) met een brand-chevron, conform de thema-referenties-accordeon. */
+.norm .toelichting {
+  margin-block: 1.5rem;
+}
+
+.norm .toelichting > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  list-style: none;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.norm .toelichting > summary::-webkit-details-marker {
+  display: none;
+}
+
+.norm .toelichting > summary::before {
+  content: "";
+  flex: none;
+  width: 0.5em;
+  height: 0.5em;
+  border-right: 2px solid var(--color-primary);
+  border-bottom: 2px solid var(--color-primary);
+  transform: rotate(-45deg);
+  transition: transform 0.15s ease;
+}
+
+.norm .toelichting[open] > summary::before {
+  transform: rotate(45deg) translate(-0.1em, -0.1em);
+}
+
+.norm .toelichting > summary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,13 +58,15 @@
   color: inherit;
 }
 
-/* Inklapbare Toelichting (standaard dicht). Summary oogt als de sectie-h2
-   (1.75rem) met een brand-chevron, conform de thema-referenties-accordeon. */
+/* Inklapbare accordeons (standaard dicht): Toelichting én Referenties krijgen
+   exact dezelfde kop — donkere tekst (1.75rem) met een blauwe chevron. Het
+   thema kleurt de referenties-kop blauw; hier gelijkgetrokken met Toelichting. */
 .norm .toelichting {
   margin-block: 1.5rem;
 }
 
-.norm .toelichting > summary {
+.norm .toelichting > summary,
+.norm .references > details > summary {
   display: flex;
   align-items: center;
   gap: 0.6rem;
@@ -73,13 +75,16 @@
   font-size: 1.75rem;
   font-weight: 700;
   line-height: 1.2;
+  color: var(--color-text);
 }
 
-.norm .toelichting > summary::-webkit-details-marker {
+.norm .toelichting > summary::-webkit-details-marker,
+.norm .references > details > summary::-webkit-details-marker {
   display: none;
 }
 
-.norm .toelichting > summary::before {
+.norm .toelichting > summary::before,
+.norm .references > details > summary::before {
   content: "";
   flex: none;
   width: 0.5em;
@@ -90,11 +95,13 @@
   transition: transform 0.15s ease;
 }
 
-.norm .toelichting[open] > summary::before {
+.norm .toelichting[open] > summary::before,
+.norm .references > details[open] > summary::before {
   transform: rotate(45deg) translate(-0.1em, -0.1em);
 }
 
-.norm .toelichting > summary:focus-visible {
+.norm .toelichting > summary:focus-visible,
+.norm .references > details > summary:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -23,15 +23,18 @@
   padding-block-end: 0.5rem;
 }
 
-/* Thema-koppen (h3, alleen binnen Normuitleg) en Voorschrift-koppen in
-   accentkleur. */
-.norm h3,
-.norm h4[id^="voorschrift"] {
+/* Heading-hiërarchie binnen Normuitleg, duidelijk onderscheiden:
+   - thema (h3) = blauwe groepskop (dominant, 1.5rem uit het thema);
+   - voorschrift (h4) = donker en kleiner, dus zichtbaar één niveau lager;
+   - criteria/indicatoren (h4) = nog kleiner én ingesprongen. */
+.norm h3 {
   color: var(--color-primary);
 }
 
-/* Scheidingslijn boven elk Voorschrift, behalve het eerste van een thema. */
+/* Voorschrift: donker (niet blauw) + kleiner dan het thema, met scheidingslijn
+   boven elk voorschrift behalve het eerste van een thema. */
 .norm h4[id^="voorschrift"] {
+  font-size: 1.15rem;
   padding-block-start: 0.75rem;
   border-block-start: 1px solid var(--color-border);
 }
@@ -41,9 +44,14 @@
   padding-block-start: 0;
 }
 
-/* Criteria en Indicatoren springen in t.o.v. Voorschrift — zowel de kop als
-   de eropvolgende inhoud (lijst of "Niet van toepassing"). margin (niet
-   padding) zodat lijst-bullets op hun plek blijven. */
+/* Criteria en Indicatoren: kleinste niveau, en springen in t.o.v. Voorschrift —
+   zowel de kop als de eropvolgende inhoud (lijst of "Niet van toepassing").
+   margin (niet padding) zodat lijst-bullets op hun plek blijven. */
+.norm h4[id^="criteria"],
+.norm h4[id^="indicatoren"] {
+  font-size: 1.05rem;
+}
+
 .norm h4[id^="criteria"],
 .norm h4[id^="indicatoren"],
 .norm h4[id^="criteria"] + *,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -23,6 +23,20 @@
   padding-block-end: 0.5rem;
 }
 
+/* Nieuw thema (h3): duidelijke overgang met ruimte + scheidingslijn (zoals
+   tussen voorschriften), behalve het eerste thema direct onder Normuitleg. */
+.norm h3 {
+  margin-block-start: 2.5rem;
+  padding-block-start: 1.25rem;
+  border-block-start: 1px solid var(--color-border);
+}
+
+.norm h3:first-of-type {
+  margin-block-start: 1.5rem;
+  padding-block-start: 0;
+  border-block-start: none;
+}
+
 /* Normuitleg (h2) en thema (h3) staan in de thema-standaardkleur (donker);
    het Voorschrift is de blauwe accent-kop. */
 .norm h4[id^="voorschrift"] {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -23,18 +23,15 @@
   padding-block-end: 0.5rem;
 }
 
-/* Heading-hiërarchie binnen Normuitleg, duidelijk onderscheiden:
-   - thema (h3) = blauwe groepskop (dominant, 1.5rem uit het thema);
-   - voorschrift (h4) = donker en kleiner, dus zichtbaar één niveau lager;
-   - criteria/indicatoren (h4) = nog kleiner én ingesprongen. */
+/* Onderscheid thema vs voorschrift via de accentkleur (niet via eigen
+   groottes — typografie komt uit het thema): thema (h3) = blauw; voorschrift
+   en criteria/indicatoren = thema-standaardkleur (donker). */
 .norm h3 {
   color: var(--color-primary);
 }
 
-/* Voorschrift: donker (niet blauw) + kleiner dan het thema, met scheidingslijn
-   boven elk voorschrift behalve het eerste van een thema. */
+/* Scheidingslijn boven elk voorschrift, behalve het eerste van een thema. */
 .norm h4[id^="voorschrift"] {
-  font-size: 1.15rem;
   padding-block-start: 0.75rem;
   border-block-start: 1px solid var(--color-border);
 }
@@ -44,14 +41,9 @@
   padding-block-start: 0;
 }
 
-/* Criteria en Indicatoren: kleinste niveau, en springen in t.o.v. Voorschrift —
-   zowel de kop als de eropvolgende inhoud (lijst of "Niet van toepassing").
-   margin (niet padding) zodat lijst-bullets op hun plek blijven. */
-.norm h4[id^="criteria"],
-.norm h4[id^="indicatoren"] {
-  font-size: 1.05rem;
-}
-
+/* Criteria en Indicatoren springen in t.o.v. Voorschrift — zowel de kop als
+   de eropvolgende inhoud (lijst of "Niet van toepassing"). margin (niet
+   padding) zodat lijst-bullets op hun plek blijven. */
 .norm h4[id^="criteria"],
 .norm h4[id^="indicatoren"],
 .norm h4[id^="criteria"] + *,

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -24,8 +24,6 @@ markup:
     endLevel: 4
 
 params:
-  feedback:
-    email: toetsingskader@inspectie-oe.nl
   search:
     enable: true
     priority_sections:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -24,6 +24,9 @@ markup:
     endLevel: 4
 
 params:
+  # Feedback-config blijft staan (de UI is verwijderd; param bewaard voor later).
+  feedback:
+    email: toetsingskader@inspectie-oe.nl
   search:
     enable: true
     priority_sections:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -46,11 +46,11 @@ menus:
     - name: Home
       pageRef: /
       weight: 1
-    - name: Over
-      pageRef: /over
-      weight: 2
     - name: Normen
       pageRef: /normen
+      weight: 2
+    - name: Over
+      pageRef: /over
       weight: 3
 
   footer-links:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -57,32 +57,11 @@ menus:
     - name: Contact
       url: https://www.inspectie-oe.nl/service/contact
       weight: 1
-    - name: RSS
-      url: https://www.inspectie-oe.nl/service/rss
+    - name: Terug naar hoofdsite
+      url: https://www.inspectie-oe.nl/
       weight: 2
-    - name: Abonneren
-      url: https://www.inspectie-oe.nl/abonneren/abonnementen
-      weight: 3
-    - name: Sitemap
-      url: https://www.inspectie-oe.nl/sitemap
-      weight: 4
-    - name: Help
-      url: https://www.inspectie-oe.nl/service/help
-      weight: 5
-    - name: Archief
-      url: https://www.inspectie-oe.nl/service/archief
-      weight: 6
-    - name: Bereikbaarheid
-      url: https://www.inspectie-oe.nl/bereikbaarheid
-      weight: 7
-    - name: Vacatures
-      url: https://www.inspectie-oe.nl/de-inspectie-overheidsinformatie-en-erfgoed/vacatures
-      weight: 8
 
   footer-rechts:
-    - name: Copyright
-      url: https://www.inspectie-oe.nl/service/copyright
-      weight: 1
     - name: Privacy
       url: https://www.inspectie-oe.nl/service/privacy
       weight: 2

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -45,7 +45,7 @@
 {{ end }}
 
 {{/* 2. Het footnotes-blok uit de body lichten en als thema-accordeon
-       onderaan tonen (ná de feedback, net als voorheen de referenties). */}}
+       onderaan tonen (net als voorheen de referenties). */}}
 {{ $refs := "" }}
 {{ $block := findRESubmatch `(?s)<div class="footnotes" role="doc-endnotes">\s*<hr\s*/?>\s*(<ol>.*?</ol>)\s*</div>` $content }}
 {{ with $block }}
@@ -89,16 +89,6 @@
 
   {{ $content | safeHTML }}
 
-  {{ with site.Params.feedback }}
-  <aside id="feedback" class="norm-feedback" aria-label="Feedback">
-    <h2>Feedback</h2>
-    <p>Heeft u opmerkingen of suggesties over deze norm? We horen het graag.</p>
-    {{ with .email }}
-    <a href="mailto:{{ . }}?subject={{ printf "Feedback: %s" $page.Title | querify "s" | strings.TrimPrefix "s=" }}" class="feedback-link">Stuur uw feedback per e-mail</a>
-    {{ end }}
-  </aside>
-  {{ end }}
-
   {{ with $refs }}{{ . | safeHTML }}{{ end }}
 
   {{- $pageNav := partial "page-nav.html" . -}}
@@ -128,7 +118,6 @@
       </li>
       {{- end -}}
       {{- with $refs }}<li><a href="#referenties">Referenties</a></li>{{ end -}}
-      {{- with site.Params.feedback }}<li><a href="#feedback">Feedback</a></li>{{ end -}}
     </ul>
   </nav>
 </aside>

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -62,6 +62,12 @@
   {{ $content = replaceRE `(<h4 id="voorschrift[^"]*">)Voorschrift(</h4>)` (printf `${1}Voorschrift %v.%d${2}` $normId (add $i 1)) $content 1 }}
 {{ end }}
 
+{{/* 4. Toelichting inklapbaar maken (standaard dicht). Het kader is naslag, dus
+       criteria/indicatoren moeten snel bereikbaar zijn zonder eerst langs de
+       toelichting te scrollen. Wrap de sectie (tot de volgende h2) in een
+       <details> (id behouden voor de TOC-link). */}}
+{{ $content = replaceRE `(?s)<h2 id="toelichting">Toelichting</h2>(.*?)(<h2 )` `<details id="toelichting" class="toelichting"><summary>Toelichting</summary>$1</details>$2` $content 1 }}
+
 {{/* TOC opbouwen uit .Fragments. Begint de body bij h2 (geen h1), dan zit
      er een lege root-heading boven de h2's; die slaan we over. */}}
 {{ $headings := .Fragments.Headings }}

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -54,6 +54,14 @@
   {{ $content = replaceRE `(?s)<div class="footnotes" role="doc-endnotes">.*?</ol>\s*</div>` "" $content }}
 {{ end }}
 
+{{/* 3. Voorschriften nummeren als "Voorschrift <norm_id>.<n>" (sequentieel
+       binnen de norm; norm_id uit de front matter). Elke replaceRE met limit 1
+       pakt het eerstvolgende nog-ongenummerde voorschrift. */}}
+{{ $normId := .Params.norm_id }}
+{{ range $i, $_ := (findRE `<h4 id="voorschrift[^"]*">Voorschrift</h4>` $content) }}
+  {{ $content = replaceRE `(<h4 id="voorschrift[^"]*">)Voorschrift(</h4>)` (printf `${1}Voorschrift %v.%d${2}` $normId (add $i 1)) $content 1 }}
+{{ end }}
+
 {{/* TOC opbouwen uit .Fragments. Begint de body bij h2 (geen h1), dan zit
      er een lege root-heading boven de h2's; die slaan we over. */}}
 {{ $headings := .Fragments.Headings }}


### PR DESCRIPTION
## Beschrijving

Een set kleine UI-fixes, elk in een eigen commit:

1. **Navigatievolgorde** — `Normen` staat nu vóór `Over` in de hoofdnavigatie.
2. **Footer opgeschoond** — alleen nog: Contact, Privacy, Cookies, Toegankelijkheid, Kwetsbaarheid melden en *Terug naar hoofdsite* (RSS, Abonneren, Sitemap, Help, Archief, Bereikbaarheid, Vacatures en Copyright verwijderd).
3. **Voorschriften genummerd** — als `<norm>.<n>` (bv. Norm 1 → Voorschrift 1.1, 1.2, …), server-side afgeleid uit `norm_id`.
4. **Feedback-optie verwijderd** uit de norm-pagina's (aside + TOC-link). De `params.feedback`-config in `hugo.yaml` blijft staan (alleen de UI is weg).
5. **Toelichting inklapbaar** — staat nu in een `<details>` en is **standaard dicht**. Het kader is naslag; zo zijn criteria/indicatoren direct bereikbaar zonder eerst langs de toelichting te scrollen. Summary in thema-stijl (accordeon-chevron).

6. **Heading-hiërarchie in Normuitleg** — thema-kop (h3, bv. *Besturing*) blijft de blauwe groepskop; *Voorschrift x.y* is nu donker en kleiner (één niveau lager), criteria/indicatoren nog kleiner + ingesprongen. Voorheen waren thema en voorschrift bijna identiek (beide blauw, vrijwel even groot).

Geen norm-content gewijzigd; alleen templates/config/CSS.

## Type wijziging

- [x] Bug fix
- [ ] Nieuwe feature
- [ ] Inhoudelijke correctie (norm-content)
- [x] Refactor
- [ ] Documentatie
- [ ] CI / build / infra

## Test plan

- [x] Hugo production build draait zonder fouten
- [x] Pre-commit gepasseerd (incl. validate-norms + unittests)
- [ ] Handmatige review op preview-URL: navigatie-volgorde, footer-links, genummerde voorschriften, geen feedback-blok, in-/uitklappen van de toelichting (+ TOC-link `#toelichting`)

## Inhoudelijke afstemming

_N.v.t. — geen norm-content gewijzigd._

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes
- [ ] `CHANGELOG.md` bijgewerkt onder `[Unreleased]`
- [ ] Gerelateerde issues gelinkt