### PR TITLE
fix: voetnoot na spatie of link wordt niet meer een lege hover-term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ changelog volgt [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Gewijzigd
+
+- Bollendiagram herontworpen naar een hub-and-spoke-visualisatie.
+- Navigatievolgorde: Normen vóór Over.
+- Footer beperkt tot contact, privacy, cookies, toegankelijkheid,
+  kwetsbaarheid melden en terug naar hoofdsite.
+- Voorschriften worden genummerd (`<norm>.<n>`, bv. 1.1, 1.2).
+- Toelichting is inklapbaar (standaard dicht); Toelichting en Referenties
+  delen één (thema-)accordeonstijl.
+- Heading-hiërarchie in Normuitleg verduidelijkt (voorschrift als accent-kop,
+  duidelijke overgang tussen thema's).
+
+### Verwijderd
+
+- Feedback-blok van de normpagina's (de `params.feedback`-config blijft).
+
+### Opgelost
+
+- Interne normverwijzingen gecorrigeerd: "(gecontroleerd) vernietigen" wees
+  naar de norm "Betrouwbaar" maar hoort naar "Gecontroleerd vernietigen"
+  (`07-informatiebeveiliging`); "risicobenadering"/"risicoanalyse" wezen naar
+  de sectie-index in plaats van de over-pagina.
+- Voetnoot-verwijzingen werken nu ook na een spatie of leesteken en op links
+  (geen lege of op-een-leesteken-geplaatste hover-term meer); een term die
+  tegelijk een interne link is, wordt blauw met de voetnoot-stippellijn.
+- Zoek-highlight knipt links in de paginatekst niet meer op.
+
 ## [0.1.0] - 2026-06-17
 
 - Normcontent verplaatst van YAML front matter naar markdown-body met

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -90,4 +90,11 @@
 }
 
 /* De inklapbare Toelichting hergebruikt de thema-`.references`-accordeonstijl
-   (zie single.html), dus hier is geen eigen accordeon-CSS meer nodig. */
+   (zie single.html). Enige project-override: de kop (én chevron via
+   currentColor) in de thema-standaardkleur (donker) i.p.v. het thema-blauw.
+   Geldt voor beide accordeons (Toelichting + Referenties).
+   Upstream-kandidaat: thema de referenties-summary-kleur als token laten zetten
+   zodat dit zonder override kan. */
+.norm .references > details > summary {
+  color: var(--color-text);
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -89,50 +89,5 @@
   color: var(--color-primary);
 }
 
-/* Inklapbare accordeons (standaard dicht): Toelichting én Referenties krijgen
-   exact dezelfde kop — donkere tekst (1.75rem) met een blauwe chevron. Het
-   thema kleurt de referenties-kop blauw; hier gelijkgetrokken met Toelichting. */
-.norm .toelichting {
-  margin-block: 1.5rem;
-}
-
-.norm .toelichting > summary,
-.norm .references > details > summary {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  cursor: pointer;
-  list-style: none;
-  font-size: 1.75rem;
-  font-weight: 700;
-  line-height: 1.2;
-  color: var(--color-text);
-}
-
-.norm .toelichting > summary::-webkit-details-marker,
-.norm .references > details > summary::-webkit-details-marker {
-  display: none;
-}
-
-.norm .toelichting > summary::before,
-.norm .references > details > summary::before {
-  content: "";
-  flex: none;
-  width: 0.5em;
-  height: 0.5em;
-  border-right: 2px solid var(--color-primary);
-  border-bottom: 2px solid var(--color-primary);
-  transform: rotate(-45deg);
-  transition: transform 0.15s ease;
-}
-
-.norm .toelichting[open] > summary::before,
-.norm .references > details[open] > summary::before {
-  transform: rotate(45deg) translate(-0.1em, -0.1em);
-}
-
-.norm .toelichting > summary:focus-visible,
-.norm .references > details > summary:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
+/* De inklapbare Toelichting hergebruikt de thema-`.references`-accordeonstijl
+   (zie single.html), dus hier is geen eigen accordeon-CSS meer nodig. */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -13,6 +13,14 @@
   }
 }
 
+/* Zoek-highlight (?q=…) wikkelt matches in <mark>, óók binnen links. De
+   thema-mark-stijl overschrijft dan de linkkleur, waardoor de link "opgeknipt"
+   oogt. Hier behoudt een highlight ín een link de linkkleur (alleen de gele
+   achtergrond blijft). Project-CSS — raakt het thema niet. */
+#main-content a mark {
+  color: inherit;
+}
+
 /* Norm page: project-specifieke decoratie op de markdown-body-structuur.
    (Voorheen op .norm-* wrappers; in het markdown-formaat zijn de koppen
    gewone h2/h3/h4, dus we scopen via .norm + heading-ids.) */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -80,6 +80,15 @@
   color: inherit;
 }
 
+/* Een ref-term die óók een interne navigatielink is (voetnoot + link naar een
+   andere pagina) krijgt de linkkleur (blauw), zodat zichtbaar is dat je erheen
+   kunt klikken; de dotted underline (voetnoot-indicator) blijft uit het thema.
+   Plain footnote-termen (href="#fn:…") blijven in tekstkleur. */
+.norm a.ref-term[href^="/"],
+.norm a.ref-term[href^="/"]:hover {
+  color: var(--color-primary);
+}
+
 /* Inklapbare accordeons (standaard dicht): Toelichting én Referenties krijgen
    exact dezelfde kop — donkere tekst (1.75rem) met een blauwe chevron. Het
    thema kleurt de referenties-kop blauw; hier gelijkgetrokken met Toelichting. */

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -73,9 +73,10 @@
 
 {{/* 4. Toelichting inklapbaar maken (standaard dicht). Het kader is naslag, dus
        criteria/indicatoren moeten snel bereikbaar zijn zonder eerst langs de
-       toelichting te scrollen. Wrap de sectie (tot de volgende h2) in een
-       <details> (id behouden voor de TOC-link). */}}
-{{ $content = replaceRE `(?s)<h2 id="toelichting">Toelichting</h2>(.*?)(<h2 )` `<details id="toelichting" class="toelichting"><summary>Toelichting</summary>$1</details>$2` $content 1 }}
+       toelichting te scrollen. Wrap in de thema-`.references`-accordeonstructuur,
+       zodat het thema 'm stylet (geen eigen accordeon-CSS nodig). id op de
+       <details> blijft voor de TOC-link (#toelichting). */}}
+{{ $content = replaceRE `(?s)<h2 id="toelichting">Toelichting</h2>(.*?)(<h2 )` `<section class="references"><details id="toelichting"><summary>Toelichting</summary>$1</details></section>$2` $content 1 }}
 
 {{/* TOC opbouwen uit .Fragments. Begint de body bij h2 (geen h1), dan zit
      er een lege root-heading boven de h2's; die slaan we over. */}}

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -36,15 +36,17 @@
     {{ $linkHTML = index (index . 0) 2 }}
   {{ end }}
   {{/* Twee passes, zodat een voorafgaande spatie (`woord [^id]`) of een link
-       (`[tekst](…) [^id]`) de hover-term niet leeg maakt:
-       A) link + optionele spatie vóór de voetnoot → de link zélf wordt de
-          ref-term (behoudt navigatie naar de norm én krijgt de tooltip);
+       (`[tekst](…)[^id]` of `[tekst](…). [^id]`) de hover-term niet leeg of op
+       een leesteken laat landen:
+       A) link + optionele leestekens + optionele spatie vóór de voetnoot → de
+          link zélf wordt de ref-term (behoudt navigatie + tooltip); het
+          leesteken blijft erachter staan;
        B) gewoon woord + optionele spatie → het woord wordt de ref-term.
        De anker-id (fnref…:N) blijft op de wrapper voor de ↩-backlinks. Wat
        geen van beide matcht (zeldzaam) blijft een zichtbaar superscript i.p.v.
        een lege term. */}}
-  {{ $linkPat := printf `<a ([^>]*)>([^<]*)</a>\s*<sup id="(fnref[0-9]*:%s)"><a href="#fn:%s" class="footnote-ref" role="doc-noteref">%s</a></sup>` $n $n $n }}
-  {{ $linkRepl := printf `<span class="ref-wrapper" id="$3"><a $1 class="ref-term">$2</a><span class="ref-tooltip" role="note"><span>%s</span>%s</span></span>` $textOnly $linkHTML }}
+  {{ $linkPat := printf `<a ([^>]*)>([^<]*)</a>([.,;:!?)]*)\s*<sup id="(fnref[0-9]*:%s)"><a href="#fn:%s" class="footnote-ref" role="doc-noteref">%s</a></sup>` $n $n $n }}
+  {{ $linkRepl := printf `<span class="ref-wrapper" id="${4}"><a ${1} class="ref-term">${2}</a><span class="ref-tooltip" role="note"><span>%s</span>%s</span></span>${3}` $textOnly $linkHTML }}
   {{ $content = replaceRE $linkPat $linkRepl $content }}
   {{ $wordPat := printf `([^\s<>]+)\s*<sup id="(fnref[0-9]*:%s)"><a href="#fn:%s" class="footnote-ref" role="doc-noteref">%s</a></sup>` $n $n $n }}
   {{ $wordRepl := printf `<span class="ref-wrapper" id="$2"><a href="#fn:%s" class="ref-term">$1</a><span class="ref-tooltip" role="note"><span>%s</span>%s</span></span>` $n $textOnly $linkHTML }}

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -35,13 +35,20 @@
     {{ $textOnly = index (index . 0) 1 }}
     {{ $linkHTML = index (index . 0) 2 }}
   {{ end }}
-  {{/* Het woord wordt een link naar het referentielijst-item (#fn:N); de
-       accordeon klapt daar automatisch open (theme referenties.js + native
-       <details>-gedrag). De anker-id (fnref…:N) blijft op de wrapper voor
-       de ↩-backlinks vanuit de lijst. */}}
-  {{ $pattern := printf `([^\s<>]*)<sup id="(fnref[0-9]*:%s)"><a href="#fn:%s" class="footnote-ref" role="doc-noteref">%s</a></sup>` $n $n $n }}
-  {{ $repl := printf `<span class="ref-wrapper" id="$2"><a href="#fn:%s" class="ref-term">$1</a><span class="ref-tooltip" role="note"><span>%s</span>%s</span></span>` $n $textOnly $linkHTML }}
-  {{ $content = replaceRE $pattern $repl $content }}
+  {{/* Twee passes, zodat een voorafgaande spatie (`woord [^id]`) of een link
+       (`[tekst](…) [^id]`) de hover-term niet leeg maakt:
+       A) link + optionele spatie vóór de voetnoot → de link zélf wordt de
+          ref-term (behoudt navigatie naar de norm én krijgt de tooltip);
+       B) gewoon woord + optionele spatie → het woord wordt de ref-term.
+       De anker-id (fnref…:N) blijft op de wrapper voor de ↩-backlinks. Wat
+       geen van beide matcht (zeldzaam) blijft een zichtbaar superscript i.p.v.
+       een lege term. */}}
+  {{ $linkPat := printf `<a ([^>]*)>([^<]*)</a>\s*<sup id="(fnref[0-9]*:%s)"><a href="#fn:%s" class="footnote-ref" role="doc-noteref">%s</a></sup>` $n $n $n }}
+  {{ $linkRepl := printf `<span class="ref-wrapper" id="$3"><a $1 class="ref-term">$2</a><span class="ref-tooltip" role="note"><span>%s</span>%s</span></span>` $textOnly $linkHTML }}
+  {{ $content = replaceRE $linkPat $linkRepl $content }}
+  {{ $wordPat := printf `([^\s<>]+)\s*<sup id="(fnref[0-9]*:%s)"><a href="#fn:%s" class="footnote-ref" role="doc-noteref">%s</a></sup>` $n $n $n }}
+  {{ $wordRepl := printf `<span class="ref-wrapper" id="$2"><a href="#fn:%s" class="ref-term">$1</a><span class="ref-tooltip" role="note"><span>%s</span>%s</span></span>` $n $textOnly $linkHTML }}
+  {{ $content = replaceRE $wordPat $wordRepl $content }}
 {{ end }}
 
 {{/* 2. Het footnotes-blok uit de body lichten en als thema-accordeon


### PR DESCRIPTION
## Beschrijving

Verbeteringen aan verwijzingen/links en accordeons op de normpagina's.

### 1. Voetnoot werd een lege of verkeerde hover-term
De voetnoot-transform maakt van het woord vóór een voetnoot een hover-term (`.ref-term`). Bij `woord [^id]` (spatie), een link `[tekst](…)[^id]`, of een link gevolgd door een leesteken `[tekst](…). [^id]` landde de term verkeerd (leeg, of op het leesteken). 31× leeg in `01-beheer`.

Fix — twee passes per voetnoot:
- **Link (+ optionele leestekens + spatie)** → de link zélf wordt de ref-term (behoudt `href`/`target`/`rel` + tooltip); het leesteken blijft erachter.
- **Gewoon woord (+ optionele spatie)** → het woord wordt de ref-term (nooit meer leeg).
- Wat niet matcht blijft een zichtbaar superscript i.p.v. een lege term.

Geverifieerd: 0 lege terms, voetnoot-aantallen + ↩-backlinks intact, werkt voor interne én externe links.

### 2. Term met voetnoot + interne link → blauw
Een ref-term die tegelijk een interne navigatielink is (bv. "vindbaar", "risicoanalyse") krijgt de linkkleur (blauw) plus de dotted underline, zodat zichtbaar is dat je er zowel overheen kunt hoveren als naartoe kunt klikken. Plain voetnoot-termen blijven tekstkleur.

### 3. Zoek-highlight knipte links op
De thema-zoekfunctie highlight bij `?q=…` matches met `<mark>` (geel), óók binnen links; de thema-`mark`-stijl overschreef dan de linkkleur. Project-CSS (`#main-content a mark { color: inherit }`) behoudt nu de linkkleur. **Raakt het thema niet.**

### 4. Toelichting-accordeon gebruikt de thema-stijl
De inklapbare Toelichting hergebruikt nu de thema-`.references`-accordeonstructuur i.p.v. eigen CSS — minder project-CSS, consistente accordeon-stijl (thema-blauw + chevron). TOC-link `#toelichting` blijft werken.

## Type wijziging

- [x] Bug fix
- [ ] Nieuwe feature
- [ ] Inhoudelijke correctie (norm-content)
- [x] Refactor
- [ ] Documentatie
- [ ] CI / build / infra

## Test plan

- [x] Hugo build + validate-norms + pre-commit groen
- [x] 0 lege ref-terms; voetnoot-aantallen + ↩-backlinks gecontroleerd
- [x] Preview: voetnoot op een link/woord (hover op het juiste woord, ook bij `link. [^id]`); zoek een term die in een link voorkomt (link niet opgeknipt); Toelichting in/uitklappen + TOC-link `#toelichting`

## Inhoudelijke afstemming

_N.v.t. — geen norm-content gewijzigd (alleen template + CSS)._

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes
- [ ] `CHANGELOG.md` bijgewerkt onder `[Unreleased]`
- [ ] Gerelateerde issues gelinkt
