### PR TITLE
docs(css): markeer thema-fix-overrides als upstream-kandidaat

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,9 +3,10 @@
   --color-banner: #007bc7;
 }
 
-/* "Over deze site" kolom expliciet breder voor het langste label
-   ("Kwetsbaarheid melden"). Theme nav { min-width: 10rem } is voor
-   alle navs hetzelfde; deze override forceert breder ipv groeien. */
+/* UPSTREAM-KANDIDAAT (thema): "Over deze site"-kolom expliciet breder voor het
+   langste label ("Kwetsbaarheid melden"). Theme nav { min-width: 10rem } is
+   voor alle navs hetzelfde; deze override forceert breder ipv groeien. Kan weg
+   als het thema de footer-nav laat auto-sizen. */
 @media (min-width: 700px) {
   body > footer .footer-columns > nav[aria-label="Over deze site"] {
     min-width: 14rem;
@@ -13,10 +14,11 @@
   }
 }
 
-/* Zoek-highlight (?q=…) wikkelt matches in <mark>, óók binnen links. De
-   thema-mark-stijl overschrijft dan de linkkleur, waardoor de link "opgeknipt"
-   oogt. Hier behoudt een highlight ín een link de linkkleur (alleen de gele
-   achtergrond blijft). Project-CSS — raakt het thema niet. */
+/* UPSTREAM-KANDIDAAT (thema): zoek-highlight (?q=…) wikkelt matches in <mark>,
+   óók binnen links. De thema-mark-stijl overschrijft dan de linkkleur, waardoor
+   de link "opgeknipt" oogt. Hier behoudt een highlight ín een link de linkkleur
+   (alleen de gele achtergrond blijft). Kan weg als de thema-highlight-walker
+   links overslaat. Raakt het thema niet. */
 #main-content a mark {
   color: inherit;
 }
@@ -73,8 +75,11 @@
   margin-inline-start: 1rem;
 }
 
-/* Referentie-term: klikbaar naar het lijstitem, maar in tekstkleur i.p.v.
-   de standaard linkkleur (de dotted underline komt uit het thema). */
+/* UPSTREAM-KANDIDAAT (thema): referentie-term in tekstkleur i.p.v. de standaard
+   linkkleur. Het thema geeft `.ref-term` alleen een dotted underline en geen
+   kleur, dus een `<a>.ref-term` valt terug op het linkblauw; deze override zet
+   'm op tekstkleur. Kan weg als het thema zelf `.ref-term { color: inherit }`
+   zet. (De dotted underline komt uit het thema.) */
 .norm a.ref-term,
 .norm a.ref-term:hover {
   color: inherit;
@@ -89,12 +94,12 @@
   color: var(--color-primary);
 }
 
-/* De inklapbare Toelichting hergebruikt de thema-`.references`-accordeonstijl
-   (zie single.html). Enige project-override: de kop (én chevron via
-   currentColor) in de thema-standaardkleur (donker) i.p.v. het thema-blauw.
-   Geldt voor beide accordeons (Toelichting + Referenties).
-   Upstream-kandidaat: thema de referenties-summary-kleur als token laten zetten
-   zodat dit zonder override kan. */
+/* UPSTREAM-KANDIDAAT (thema): de inklapbare Toelichting hergebruikt de
+   thema-`.references`-accordeonstijl (zie single.html). Enige project-override:
+   de kop (én chevron via currentColor) in de thema-standaardkleur (donker)
+   i.p.v. het thema-blauw. Geldt voor beide accordeons (Toelichting +
+   Referenties). Kan weg als het thema de summary-kleur als token zet (of niet
+   hardcoded op blauw). */
 .norm .references > details > summary {
   color: var(--color-text);
 }


### PR DESCRIPTION
## Beschrijving

Audit van de project-CSS (`assets/css/main.css`, `bollendiagram.css`): wat kan vervangen worden door het Hugo-thema?

**Conclusie:** vrijwel niets is veilig te verwijderen. `main.css` (100 regels) is al mager en token-gebaseerd (gebruikt al `var(--color-primary/border/text)`). De thema-`.ref-term` zet bovendien alleen een dotted underline en géén kleur, dus die overrides zijn nodig, niet redundant.

Deze PR voegt **geen functionele wijziging** toe; het markeert de 4 rules die alléén bestaan omdat het thema iets niet doet, uniform als `UPSTREAM-KANDIDAAT (thema)` zodat ze greppbaar zijn en weg kunnen zodra het thema het oplost.

### Niet vervangbaar — terecht project-specifiek
- `:root` brand-tokens (#007bc7) — *is* de bewuste merkkleur (Inspectie OE).
- Norm-pagina-decoratie (Normuitleg-accentlijn, thema-overgang h3, voorschrift/criteria/indicator-hiërarchie) — het thema kent de norm-structuur niet.
- `.ref-term[href^="/"]` blauw — eigen feature (term die ook een link is).

### Upstream-kandidaten (gemarkeerd, niet verwijderd)
| Rule | Bestaat omdat | Thema-oplossing |
|---|---|---|
| footer-nav-kolombreedte | `min-width:10rem` te smal voor "Kwetsbaarheid melden" | nav auto-sizing |
| `#main-content a mark { color: inherit }` | zoek-highlight knipt links op | highlight-walker links laten overslaan |
| `.ref-term { color: inherit }` | thema zet geen kleur → `<a>` valt terug op linkblauw | thema `.ref-term { color: inherit }` |
| `.references > details > summary { color }` | thema kleurt accordeon-kop hardcoded blauw | summary-kleur als token |

### bollendiagram.css
Custom SVG-component, niet vervangbaar. De hardcoded `#007bc7` (main-bol) bewust **niet** naar `var(--color-primary)` gezet: dat zou in dark-mode de bol licht maken (#80d5fc) en de witte labels onleesbaar.

## Type wijziging

- [ ] Bug fix
- [ ] Nieuwe feature
- [ ] Inhoudelijke correctie (norm-content)
- [ ] Refactor
- [x] Documentatie (in-code markers)
- [ ] CI / build / infra

## Test plan

- [x] Build identiek (alleen comments gewijzigd), pre-commit groen
- [x] `grep UPSTREAM-KANDIDAAT assets/css/main.css` → 4 treffers

## Inhoudelijke afstemming

_N.v.t._

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes
- [ ] `CHANGELOG.md` bijgewerkt (n.v.t. — geen gedragswijziging)
- [ ] Gerelateerde issues gelinkt
