### PR TITLE
fix(toc): vloeiende scroll-spy highlight in 'Op deze pagina'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ changelog volgt [Semantic Versioning][semver].
   (geen lege of op-een-leesteken-geplaatste hover-term meer); een term die
   tegelijk een interne link is, wordt blauw met de voetnoot-stippellijn.
 - Zoek-highlight knipt links in de paginatekst niet meer op.
+- "Op deze pagina"-TOC volgt de actieve sectie nu vloeiend mee; voorheen
+  verdween de highlight in de voorschrift-/criteria-/indicator-blokken
+  (project-scroll-spy; thema-fix als upstream-PR ingediend).
 
 ## [0.1.0] - 2026-06-17
 

--- a/assets/js/toc-scrollspy.js
+++ b/assets/js/toc-scrollspy.js
@@ -1,0 +1,48 @@
+// Scroll-spy voor de "Op deze pagina"-TOC: highlight de sectie waar je bent.
+//
+// Het thema heeft een eigen scroll-spy (toc.js), maar die kijkt naar álle
+// h2/h3/h4[id]-koppen — óók de voorschrift/criteria/indicatoren (h4) die niet in
+// de TOC staan, en niet naar de Toelichting (die is een <summary>, geen <h2>).
+// Zit je in een h4-blok, dan vindt het thema geen TOC-link en verdwijnt de
+// highlight (sporadisch, springerig gedrag).
+//
+// Deze versie kijkt alléén naar koppen die écht een TOC-link hebben (de
+// link-targets), zodat de actieve sectie vloeiend meeloopt. Registratie op
+// `load` zodat hij ná de thema-scroll-spy draait en wint.
+(function () {
+  function setup() {
+    var toc = document.getElementById('toc');
+    if (!toc) return;
+
+    // TOC-links → hun doelkop, in documentvolgorde.
+    var entries = [];
+    toc.querySelectorAll('a[href^="#"]').forEach(function (link) {
+      var id = decodeURIComponent(link.getAttribute('href').slice(1));
+      var el = id && document.getElementById(id);
+      if (el) entries.push({ link: link, el: el });
+    });
+    if (!entries.length) return;
+
+    var ticking = false;
+    function update() {
+      ticking = false;
+      var threshold = window.innerHeight * 0.25;
+      var current = null;
+      for (var i = 0; i < entries.length; i++) {
+        if (entries[i].el.getBoundingClientRect().top <= threshold) current = entries[i];
+        else break;
+      }
+      entries.forEach(function (e) { e.link.classList.remove('active'); });
+      if (current) current.link.classList.add('active');
+    }
+    function onScroll() {
+      if (!ticking) { ticking = true; window.requestAnimationFrame(update); }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    update();
+  }
+
+  window.addEventListener('load', setup);
+})();

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -137,5 +137,10 @@
     </ul>
   </nav>
 </aside>
+
+{{/* Scroll-spy: highlight de actieve sectie in de TOC (alleen koppen mét een
+     TOC-link; draait ná de thema-scroll-spy). CSP-veilig 'self'-script. */}}
+{{- $spy := resources.Get "js/toc-scrollspy.js" | fingerprint "md5" -}}
+<script src="{{ $spy.RelPermalink }}"></script>
 {{- end -}}
 {{ end }}


### PR DESCRIPTION
## Beschrijving

De "Op deze pagina"-TOC highlightte de actieve sectie maar **sporadisch** (springerig, niet vloeiend meelopend).

**Oorzaak (thema-beperking):** de thema-scroll-spy (`toc.js`) volgt **alle** `article h2[id], h3[id], h4[id]`-koppen. Deze normpagina's hebben veel **h4's** (Voorschrift / Criteria / Indicatoren) die bewust **niet** in de TOC staan (anders slibt die dicht), en de Toelichting is nu een `<summary>` i.p.v. `<h2>`. Zodra je in een h4-blok scrolt, pakt het thema die h4 als huidige kop, vindt geen TOC-link `#<h4-id>`, en haalt de highlight weg → highlight zichtbaar alleen rond h2/h3.

**Fix (project-workaround):** `assets/js/toc-scrollspy.js` volgt alléén de koppen die écht een TOC-link hebben (de link-targets), met `requestAnimationFrame`-throttling; geladen als CSP-veilig `'self'`-script op normpagina's met een TOC, en geregistreerd op `load` zodat het ná de thema-scroll-spy draait en wint.

Geverifieerd: script geladen, alle 8 TOC-links hebben een bestaand doel-id, geen inline scripts (CSP-veilig).

## Upstream-fix (thema — de echte oplossing)

Dit project-script kan weg zodra het thema de scroll-spy beperkt tot koppen die in de TOC staan. Voorstel voor `assets/js/toc.js` in `hugo-theme-rijksoverheid` — bouw de heading-lijst uit de TOC-links i.p.v. uit alle h2/h3/h4:

```js
// i.p.v.
const headings = Array.from(
  document.querySelectorAll("article h2[id], article h3[id], article h4[id]")
);

// gebruik de koppen die écht een TOC-link hebben:
const tocLinks = Array.from(document.querySelectorAll(".toc a[href^='#']"));
const headings = tocLinks
  .map((l) => document.getElementById(decodeURIComponent(l.getAttribute("href").slice(1))))
  .filter(Boolean);
```

Zo werkt de scroll-spy met elke TOC (h2/h3-only, summary-koppen, kern-callout) zonder dat secties zonder TOC-link de highlight uitzetten.

## Type wijziging

- [x] Bug fix
- [ ] Nieuwe feature
- [ ] Inhoudelijke correctie (norm-content)
- [ ] Refactor
- [ ] Documentatie
- [ ] CI / build / infra

## Test plan

- [x] Build + pre-commit groen; script geladen, TOC-mapping volledig
- [x] Preview: scroll een normpagina door → de actieve sectie in "Op deze pagina" loopt vloeiend mee (ook door de voorschrift/criteria/indicator-blokken)

## Inhoudelijke afstemming

_N.v.t._

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes (additief script; thema-scroll-spy blijft, wordt overschreven)
- [x] `CHANGELOG.md` bijgewerkt onder `[Unreleased]`
- [ ] Gerelateerde issues gelinkt (upstream theme-issue als kandidaat)
