### PR TITLE
Voeg OCW logo toe aan PDF 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ changelog volgt [Semantic Versioning][semver].
   duidelijke overgang tussen thema's).
 - PDF-export toegevoegd: downloadbare Rijkshuisstijl-PDF per normpagina en
   voor het hele toetsingskader, met titelpagina, release-tag en
-  downloaddatum. Client-side gegenereerd met pdfMake; CSP-veilig.
+  downloaddatum. Client-side gegenereerd met pdfMake; CSP-veilig. Als
+  briefhoofd op elke pagina de volledige logo-lockup: Rijksoverheidslint met
+  "Inspectie Overheidsinformatie en Erfgoed" en "Ministerie van Onderwijs,
+  Cultuur en Wetenschap".
 
 ### Verwijderd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ changelog volgt [Semantic Versioning][semver].
   downloaddatum. Client-side gegenereerd met pdfMake; CSP-veilig. Als
   briefhoofd op elke pagina de volledige logo-lockup: Rijksoverheidslint met
   "Inspectie Overheidsinformatie en Erfgoed" en "Ministerie van Onderwijs,
-  Cultuur en Wetenschap".
+  Cultuur en Wetenschap". Het lint staat horizontaal gecentreerd en loopt af
+  aan de bovenrand van de pagina, zoals de huisstijl voorschrijft.
 
 ### Verwijderd
 

--- a/assets/js/pdf-export.js
+++ b/assets/js/pdf-export.js
@@ -5,6 +5,8 @@
   var BRAND = '#007bc7'
   // Rijkshuisstijl-donkerblauw: kleur van het lint en het woordmerk ernaast.
   var LOGO_BLUE = '#154273'
+  // Breedte van het lint in punten; de SVG is 1:2, dus de hoogte is het dubbele.
+  var LOGO_W = 26
   var dateFmt = new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' })
 
   var styles = {
@@ -122,27 +124,30 @@
     base.defaultStyle = { font: 'ROSans', fontSize: 10.5, color: '#1a1a1a' }
     base.styles = styles
     base.info = { title: data.titel, author: 'Inspectie Overheidsinformatie en Erfgoed', subject: 'Versie: ' + (data.versie || '') }
-    base.header = function () {
-      // Rijkshuisstijl-lockup linksboven op elke pagina (running letterhead),
-      // zonder lijn: lint + organisatienaam + ministerie, zoals de header van
+    base.header = function (currentPage, pageCount, pageSize) {
+      // Rijkshuisstijl-lockup bovenaan elke pagina (running letterhead), zonder
+      // lijn: lint + organisatienaam + ministerie, zoals de header van
       // inspectie-oe.nl. De tekst staat in RO Sans (al in de VFS) i.p.v. een
       // woordmerk-SVG, zodat hij scherp en selecteerbaar blijft.
-      // Het lint is 1:2 (viewBox 50x100), dus 26 breed → 52 hoog; de
-      // top-marge van de tekst centreert het tekstblok (±21 hoog) verticaal.
-      return {
-        columns: [
-          { svg: window.TKPDF.PDF_LOGO_SVG, width: 26 },
-          {
-            width: '*',
-            margin: [8, 16, 0, 0],
-            stack: [
-              { text: 'Inspectie Overheidsinformatie en Erfgoed', fontSize: 9.5, bold: true, color: LOGO_BLUE, lineHeight: 1.15 },
-              { text: 'Ministerie van Onderwijs, Cultuur en Wetenschap', fontSize: 8, color: LOGO_BLUE, lineHeight: 1.15, margin: [0, 1, 0, 0] }
-            ]
-          }
-        ],
-        margin: [48, 14, 48, 0]
-      }
+      // Het lint is 1:2 (viewBox 50x100), dus LOGO_W breed → 2x zo hoog.
+      // Beide onderdelen staan met absolutePosition op de pagina (zoals de
+      // logolockup in de AI-verordening-beslishulp) i.p.v. in de header-flow:
+      // zo ligt het lint gegarandeerd tegen de bovenrand (y = 0) en precies in
+      // het paginamidden, los van pageMargins. In de huisstijl loopt het lint
+      // af aan de bovenrand; het mag er niet los onder zweven. De tekst sluit
+      // rechts op het lint aan en staat er verticaal op gecentreerd.
+      var lintX = (pageSize.width - LOGO_W) / 2
+      return [
+        { svg: window.TKPDF.PDF_LOGO_SVG, width: LOGO_W, absolutePosition: { x: lintX, y: 0 } },
+        {
+          width: 220,
+          absolutePosition: { x: lintX + LOGO_W + 8, y: 16 },
+          stack: [
+            { text: 'Inspectie Overheidsinformatie en Erfgoed', fontSize: 9.5, bold: true, color: LOGO_BLUE, lineHeight: 1.15 },
+            { text: 'Ministerie van Onderwijs, Cultuur en Wetenschap', fontSize: 8, color: LOGO_BLUE, lineHeight: 1.15, margin: [0, 1, 0, 0] }
+          ]
+        }
+      ]
     }
     base.footer = function (currentPage, pageCount) {
       // Dunne scheidingslijn + alleen paginanummer (versie/datum staan op de

--- a/assets/js/pdf-export.js
+++ b/assets/js/pdf-export.js
@@ -3,6 +3,8 @@
 // addVirtualFileSystem) en window.TKPDF (converter + base64-assets).
 (function () {
   var BRAND = '#007bc7'
+  // Rijkshuisstijl-donkerblauw: kleur van het lint en het woordmerk ernaast.
+  var LOGO_BLUE = '#154273'
   var dateFmt = new Intl.DateTimeFormat('nl-NL', { day: 'numeric', month: 'long', year: 'numeric' })
 
   var styles = {
@@ -121,10 +123,25 @@
     base.styles = styles
     base.info = { title: data.titel, author: 'Inspectie Overheidsinformatie en Erfgoed', subject: 'Versie: ' + (data.versie || '') }
     base.header = function () {
-      // Logo gecentreerd bovenaan elke pagina (running letterhead), zonder lijn.
+      // Rijkshuisstijl-lockup linksboven op elke pagina (running letterhead),
+      // zonder lijn: lint + organisatienaam + ministerie, zoals de header van
+      // inspectie-oe.nl. De tekst staat in RO Sans (al in de VFS) i.p.v. een
+      // woordmerk-SVG, zodat hij scherp en selecteerbaar blijft.
+      // Het lint is 1:2 (viewBox 50x100), dus 26 breed → 52 hoog; de
+      // top-marge van de tekst centreert het tekstblok (±21 hoog) verticaal.
       return {
-        columns: [{ text: '', width: '*' }, { svg: window.TKPDF.PDF_LOGO_SVG, width: 28 }, { text: '', width: '*' }],
-        margin: [0, 14, 0, 0]
+        columns: [
+          { svg: window.TKPDF.PDF_LOGO_SVG, width: 26 },
+          {
+            width: '*',
+            margin: [8, 16, 0, 0],
+            stack: [
+              { text: 'Inspectie Overheidsinformatie en Erfgoed', fontSize: 9.5, bold: true, color: LOGO_BLUE, lineHeight: 1.15 },
+              { text: 'Ministerie van Onderwijs, Cultuur en Wetenschap', fontSize: 8, color: LOGO_BLUE, lineHeight: 1.15, margin: [0, 1, 0, 0] }
+            ]
+          }
+        ],
+        margin: [48, 14, 48, 0]
       }
     }
     base.footer = function (currentPage, pageCount) {

--- a/tests/js/pdf-doc.test.mjs
+++ b/tests/js/pdf-doc.test.mjs
@@ -64,6 +64,10 @@ test('norm-doc: header, kern, body, disclaimer, fonts', async () => {
   const logoCol = dd.header(1).columns.find(c => c.svg)
   assert.ok(logoCol, 'logo-kolom aanwezig')
   assert.match(logoCol.svg, /^<svg/)
+  // Rijkshuisstijl-lockup: lint + organisatienaam + ministerie (OCW).
+  const wordmark = JSON.stringify(dd.header(1).columns.find(c => c.stack))
+  assert.match(wordmark, /Inspectie Overheidsinformatie en Erfgoed/)
+  assert.match(wordmark, /Ministerie van Onderwijs, Cultuur en Wetenschap/)
   assert.ok(dd.header(2).columns.find(c => c.svg), 'logo ook op pagina 2 (running letterhead)')
 })
 

--- a/tests/js/pdf-doc.test.mjs
+++ b/tests/js/pdf-doc.test.mjs
@@ -61,14 +61,20 @@ test('norm-doc: header, kern, body, disclaimer, fonts', async () => {
   assert.ok(dd.content.some(b => b.ul && typeof b.ul[0] === 'string' && b.ul[0].includes('automatisch gegenereerd')))
   // header (logo op elke pagina) + footer (stack met paginanummer)
   assert.match(JSON.stringify(dd.footer(2, 5)), /Pagina 2 van 5/)
-  const logoCol = dd.header(1).columns.find(c => c.svg)
-  assert.ok(logoCol, 'logo-kolom aanwezig')
-  assert.match(logoCol.svg, /^<svg/)
+  const A4 = { width: 595.28, height: 841.89 }
+  const lint = dd.header(1, 6, A4).find(c => c.svg)
+  assert.ok(lint, 'lint aanwezig')
+  assert.match(lint.svg, /^<svg/)
+  // Het lint loopt af aan de bovenrand (y = 0) en staat horizontaal gecentreerd;
+  // zonder dat zweeft het logo los onder de paginarand.
+  assert.equal(lint.absolutePosition.y, 0, 'lint tegen de bovenrand')
+  assert.equal(lint.absolutePosition.x + lint.width / 2, A4.width / 2, 'lint horizontaal gecentreerd')
   // Rijkshuisstijl-lockup: lint + organisatienaam + ministerie (OCW).
-  const wordmark = JSON.stringify(dd.header(1).columns.find(c => c.stack))
-  assert.match(wordmark, /Inspectie Overheidsinformatie en Erfgoed/)
-  assert.match(wordmark, /Ministerie van Onderwijs, Cultuur en Wetenschap/)
-  assert.ok(dd.header(2).columns.find(c => c.svg), 'logo ook op pagina 2 (running letterhead)')
+  const wordmark = dd.header(1, 6, A4).find(c => c.stack)
+  assert.match(JSON.stringify(wordmark), /Inspectie Overheidsinformatie en Erfgoed/)
+  assert.match(JSON.stringify(wordmark), /Ministerie van Onderwijs, Cultuur en Wetenschap/)
+  assert.ok(wordmark.absolutePosition.x > lint.absolutePosition.x + lint.width, 'woordmerk rechts van het lint')
+  assert.ok(dd.header(2, 6, A4).find(c => c.svg), 'logo ook op pagina 2 (running letterhead)')
 })
 
 test('kader-doc: inhoudsopgave + 8 normen op eigen pagina, in toc opgenomen', async () => {


### PR DESCRIPTION
## Beschrijving


<img width="365" height="137" alt="Screenshot 2026-08-03 at 11 38 20" src="https://github.com/user-attachments/assets/ff11b8e0-2ed6-474d-90a6-01d038c87c41" />
in plaats van: 
<img width="257" height="138" alt="Screenshot 2026-08-03 at 11 39 01" src="https://github.com/user-attachments/assets/9f589932-56e7-48ed-bbc7-3f27dd2befbc" />


Op de PDF-export. 


## Type wijziging

- [ ] Bug fix
- [ ] Nieuwe feature
- [ ] Inhoudelijke correctie (norm-content)
- [ ] Refactor
- [ ] Documentatie
- [ ] CI / build / infra

## Test plan

- [ ] Lokaal `just build` draait zonder fouten
- [ ] Pre-commit hooks gepasseerd
- [ ] Handmatige review op preview-URL (link in PR-comments)
- [ ] Overig: ...

## Inhoudelijke afstemming

_Alleen invullen bij wijzigingen aan norm-content._

Wie heeft de inhoud inhoudelijk geverifieerd? Verwijs naar persoon,
team, of bron.

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes (of: hieronder beschreven)
- [x] `CHANGELOG.md` bijgewerkt onder `[Unreleased]`
- [x] Gerelateerde issues gelinkt (bijv. `Closes #123`)
