### PR TITLE
fix(pdf): neem voorschriftnummering over in de PDF-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ changelog volgt [Semantic Versioning][semver].
 
 ### Opgelost
 
+- Voorschriftnummering (`<norm>.<n>`) ontbrak in de PDF-export; de nummering
+  is nu gedeeld tussen webpagina en PDF, zowel per norm als in de kader-PDF.
 - Interne normverwijzingen gecorrigeerd: "(gecontroleerd) vernietigen" wees
   naar de norm "Betrouwbaar" maar hoort naar "Gecontroleerd vernietigen"
   (`07-informatiebeveiliging`); "risicobenadering"/"risicoanalyse" wezen naar

--- a/layouts/_default/list.pdf.json
+++ b/layouts/_default/list.pdf.json
@@ -9,7 +9,7 @@
       "norm_id" (string .Params.norm_id)
       "slug" .File.ContentBaseName
       "kern_html" $kern
-      "body_html" .Content) -}}
+      "body_html" (partial "nummer-voorschriften.html" (dict "content" .Content "norm_id" .Params.norm_id))) -}}
 {{- end -}}
 {{- dict
   "kind" "kader"

--- a/layouts/_default/single.pdf.json
+++ b/layouts/_default/single.pdf.json
@@ -7,7 +7,7 @@
   "norm_id" (string .Params.norm_id)
   "norm_titel" .Params.norm_titel
   "kern_html" $kern
-  "body_html" .Content
+  "body_html" (partial "nummer-voorschriften.html" (dict "content" .Content "norm_id" .Params.norm_id))
   "url" .Permalink
   "versie" (site.Params.versie | default "")
   | jsonify -}}

--- a/layouts/_partials/nummer-voorschriften.html
+++ b/layouts/_partials/nummer-voorschriften.html
@@ -1,0 +1,16 @@
+{{- /*
+  Nummert de "Voorschrift"-koppen in een gerenderde norm-body als
+  "Voorschrift <norm_id>.<n>", sequentieel binnen de norm. Elke replaceRE met
+  limit 1 pakt het eerstvolgende nog-ongenummerde voorschrift.
+
+  Zowel de HTML-pagina als de PDF-output gebruiken dit, zodat de nummering in
+  de PDF gelijk is aan die op de webpagina.
+
+  Aanroep: {{ partial "nummer-voorschriften.html" (dict "content" .Content "norm_id" .Params.norm_id) }}
+*/ -}}
+{{- $content := .content -}}
+{{- $normId := .norm_id -}}
+{{- range $i, $_ := (findRE `<h4 id="voorschrift[^"]*">Voorschrift</h4>` $content) -}}
+  {{- $content = replaceRE `(<h4 id="voorschrift[^"]*">)Voorschrift(</h4>)` (printf `${1}Voorschrift %v.%d${2}` $normId (add $i 1)) $content 1 -}}
+{{- end -}}
+{{- return $content -}}

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -63,13 +63,9 @@
   {{ $content = replaceRE `(?s)<div class="footnotes" role="doc-endnotes">.*?</ol>\s*</div>` "" $content }}
 {{ end }}
 
-{{/* 3. Voorschriften nummeren als "Voorschrift <norm_id>.<n>" (sequentieel
-       binnen de norm; norm_id uit de front matter). Elke replaceRE met limit 1
-       pakt het eerstvolgende nog-ongenummerde voorschrift. */}}
-{{ $normId := .Params.norm_id }}
-{{ range $i, $_ := (findRE `<h4 id="voorschrift[^"]*">Voorschrift</h4>` $content) }}
-  {{ $content = replaceRE `(<h4 id="voorschrift[^"]*">)Voorschrift(</h4>)` (printf `${1}Voorschrift %v.%d${2}` $normId (add $i 1)) $content 1 }}
-{{ end }}
+{{/* 3. Voorschriften nummeren als "Voorschrift <norm_id>.<n>". Gedeeld met de
+       PDF-output, zodat beide dezelfde nummering tonen. */}}
+{{ $content = partial "nummer-voorschriften.html" (dict "content" $content "norm_id" .Params.norm_id) }}
 
 {{/* 4. Toelichting inklapbaar maken (standaard dicht). Het kader is naslag, dus
        criteria/indicatoren moeten snel bereikbaar zijn zonder eerst langs de


### PR DESCRIPTION
## Aanleiding

Klantfeedback: de nummering van de voorschriften zoals te zien op de webpagina ("Voorschrift 1.1", "Voorschrift 1.2", …) ontbreekt in de PDF's.

## Oorzaak

De nummering werd toegepast in `layouts/normen/single.html`, als post-processing op de gerenderde `.Content` van de HTML-pagina. De PDF-outputs (`layouts/_default/single.pdf.json` en `layouts/_default/list.pdf.json`) serialiseren de ruwe `.Content` en misten die stap; de PDF toonde daardoor kale "Voorschrift"-koppen.

## Oplossing

De nummerlogica staat nu in een gedeelde partial `layouts/_partials/nummer-voorschriften.html`, aangeroepen door alle drie de templates. Eén bron van waarheid, dus web en PDF kunnen niet meer uit de pas lopen.

## Verificatie

Productiebuild (`hugo --environment production --minify`), daarna de gegenereerde output vergeleken:

| norm | HTML | PDF-JSON |
| --- | --- | --- |
| 01-beheer | 1.1 – 1.8 | 1.1 – 1.8 |
| 02-overzicht | 2.1 | 2.1 |
| 03-ordeningsstructuur | 3.1 | 3.1 |
| 04-metadatering | 4.1 | 4.1 |
| 05-vindbaarheid | 6.1 | 6.1 |
| 06-vernietigen | 5.1 | 5.1 |
| 07-informatiebeveiliging | 7.1 | 7.1 |
| 08-periodieke-evaluatie | 8.1 | 8.1 |

De kader-PDF (`normen/index.pdf.json`) bevat dezelfde nummers voor alle acht normen. (De afwijkende map-/nummercombinaties bij 05 en 06 komen uit de bestaande aliassen; `norm_id` is leidend, conform `CLAUDE.md`.)

Verder: `npm test` → 15/15 groen, `pre-commit run --all-files` → alles Passed.

Niet geraakt door deze PR: de inhoudsopgave in de rechterkolom toont de kop nog zonder nummer, omdat die uit `.Fragments` komt (vóór de post-processing). Bestaand gedrag, apart op te pakken als het stoort.