### PR TITLE
fix(toc): inhoudsopgave standaard open en op elke breedte bedienbaar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ changelog volgt [Semantic Versioning][semver].
   delen één (thema-)accordeonstijl.
 - Heading-hiërarchie in Normuitleg verduidelijkt (voorschrift als accent-kop,
   duidelijke overgang tussen thema's).
+- "Op deze pagina" staat nu op élke pagina met een inhoudsopgave standaard
+  open, en is op elke schermbreedte in- en uitklapbaar. De keuze van de
+  gebruiker wordt onthouden.
 - PDF-export toegevoegd: downloadbare Rijkshuisstijl-PDF per normpagina en
   voor het hele toetsingskader, met titelpagina, release-tag en
   downloaddatum. Client-side gegenereerd met pdfMake; CSP-veilig. Als
@@ -36,6 +39,14 @@ changelog volgt [Semantic Versioning][semver].
 
 ### Opgelost
 
+- De inhoudsopgave was op schermen smaller dan 950px niet te openen: de TOC
+  stond dicht en de toggle was daar verborgen. Op de normpagina's stond de
+  TOC wél open, maar met `aria-expanded="false"` op de knop — een
+  screenreader meldde "ingeklapt" terwijl de lijst zichtbaar was.
+- Op smalle schermen stonden de inhoudsopgave en de "Download als PDF"-knop
+  onder het hele artikel; die staan nu boven de tekst.
+- Lege `/tags/`- en `/categories/`-pagina's werden gegenereerd en in de
+  sitemap opgenomen. Taxonomieën zijn uitgezet.
 - Voorschriftnummering (`<norm>.<n>`) ontbrak in de PDF-export; de nummering
   is nu gedeeld tussen webpagina en PDF, zowel per norm als in de kader-PDF.
 - Interne normverwijzingen gecorrigeerd: "(gecontroleerd) vernietigen" wees

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -21,6 +21,38 @@
   color: inherit;
 }
 
+/* TOC-toggle op élke schermbreedte tonen. Het thema verbergt 'm onder 950px,
+   terwijl de TOC zelf standaard dicht staat (opacity/visibility/max-height op
+   0) — daardoor was "Op deze pagina" op mobiel niet te openen. Nu staat de TOC
+   standaard open (js/toc-default-open.js) en kan de gebruiker 'm overal
+   in- en uitklappen. Upstream-kandidaat voor het thema. */
+button.toc-toggle {
+  display: flex;
+}
+
+/* Onder 950px is er geen sidebar-kolom (het thema zet het tweekolomsgrid pas
+   vanaf 950px aan), dus valt de TOC-aside ná het artikel. Op een normpagina
+   betekende dat: eerst de hele norm doorscrollen voordat je de inhoudsopgave
+   én de "Download als PDF"-knop ziet. Zet de aside daar bovenaan; sticky heeft
+   zonder eigen kolom geen functie, dus die zetten we uit. */
+@media (max-width: 949px) {
+  main:has(.toc) {
+    display: flex;
+    flex-direction: column;
+  }
+
+  #toc {
+    order: -1;
+    position: static;
+    padding-top: 0;
+  }
+
+  /* Alleen in open toestand: de dichte toestand leunt op max-height 0. */
+  #toc.is-open {
+    max-height: none;
+  }
+}
+
 /* Norm page: project-specifieke decoratie op de markdown-body-structuur.
    (Voorheen op .norm-* wrappers; in het markdown-formaat zijn de koppen
    gewone h2/h3/h4, dus we scopen via .norm + heading-ids.) */

--- a/assets/js/toc-default-open.js
+++ b/assets/js/toc-default-open.js
@@ -1,0 +1,32 @@
+// TOC standaard open, op elke pagina.
+//
+// Het thema laat de "Op deze pagina"-aside dicht en opent 'm alleen als de
+// gebruiker eerder op de toggle klikte (localStorage `toc-open`). Voor een
+// naslagwerk is de inhoudsopgave het primaire navigatiemiddel, dus zonder
+// opgeslagen voorkeur hoort die open te staan. Eerder loste de normpagina dat
+// op met een hardgecodeerde `is-open`-class; dat botste met de toggle-status
+// (aria-expanded bleef "false") en negeerde de voorkeur van de gebruiker.
+//
+// Draait als laatste in de thema-bundel (zie layouts/_partials/scripts.html),
+// dus ná theme/js/toc.js. Heeft de gebruiker wél een voorkeur, dan heeft het
+// thema die al toegepast en doen we niets.
+//
+// Upstream-kandidaat: het thema een `toc_default_open`-param geven.
+(function () {
+  var stored = null;
+  try {
+    stored = localStorage.getItem('toc-open');
+  } catch (e) {
+    // localStorage geblokkeerd (privacymodus): val terug op standaard open.
+  }
+  if (stored !== null) return;
+
+  var toc = document.getElementById('toc');
+  var toggle = document.querySelector('.toc-toggle');
+  if (!toc || !toggle) return;
+
+  toc.classList.add('is-open');
+  toggle.setAttribute('aria-expanded', 'true');
+  var label = toggle.querySelector('.visually-hidden');
+  if (label) label.textContent = 'Inhoudsopgave verbergen';
+})();

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,6 +6,12 @@ title: Toetsingskader Archiefwet
 enableRobotsTXT: true
 enableGitInfo: true
 
+# Geen tags/categories in dit kader; zonder dit genereert Hugo lege
+# /tags/- en /categories/-pagina's die wél in de sitemap belanden.
+disableKinds:
+  - taxonomy
+  - term
+
 outputFormats:
   pdf:
     mediaType: application/json

--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -1,0 +1,16 @@
+{{/* Shadowt _partials/scripts.html uit het thema om js/toc-default-open.js
+     áchteraan de bundel te hangen: dat script moet ná theme/js/toc.js draaien
+     (dat herstelt de opgeslagen TOC-voorkeur) en moet op élke pagina laden,
+     niet alleen op de normpagina's.
+
+     LET OP: de bundel-lijst hieronder is een kopie van het thema. Controleer
+     bij een theme-update (`just update-theme`) of het thema scripts heeft
+     toegevoegd of hernoemd, en pas deze lijst aan. */}}
+{{- $baseJs := resources.Get "js/base.js" -}}
+{{- $tocJs := resources.Get "js/toc.js" -}}
+{{- $referentiesJs := resources.Get "js/referenties.js" -}}
+{{- $fuseJs := resources.Get "lib/fuse/fuse.min.js" -}}
+{{- $searchJs := resources.Get "js/search.js" -}}
+{{- $tocDefaultOpenJs := resources.Get "js/toc-default-open.js" -}}
+{{- $js := slice $baseJs $tocJs $referentiesJs $fuseJs $searchJs $tocDefaultOpenJs | resources.Concat "js/bundle.js" | fingerprint "md5" -}}
+<script src="{{ $js.RelPermalink }}"></script>

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -114,7 +114,10 @@
 </article>
 
 {{- if $hasToc -}}
-<aside id="toc" class="toc is-open" aria-label="Op deze pagina">
+{{/* Geen hardgecodeerde `is-open`: die botste met aria-expanded op de toggle en
+     negeerde de opgeslagen voorkeur. Standaard-open regelt nu
+     assets/js/toc-default-open.js, site-breed en in sync met de toggle. */}}
+<aside id="toc" class="toc" aria-label="Op deze pagina">
   {{- with .OutputFormats.Get "pdf" -}}
   <a class="button pdf-download" href="{{ .RelPermalink }}" data-pdf-url="{{ .RelPermalink }}" download>
     {{- partial "icon.html" "download" -}}<span>Download als PDF</span>

--- a/tests/js/toc-default-open.test.mjs
+++ b/tests/js/toc-default-open.test.mjs
@@ -1,0 +1,71 @@
+// Gedrag van assets/js/toc-default-open.js: de "Op deze pagina"-TOC staat
+// standaard open, maar een opgeslagen voorkeur wint altijd.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { parseHTML } from 'linkedom'
+
+const src = readFileSync(new URL('../../assets/js/toc-default-open.js', import.meta.url), 'utf8')
+
+// Rendert de markup zoals layouts/normen/single.html en het thema die opleveren:
+// toggle met aria-expanded="false" + aside zonder is-open.
+function setup({ stored = null, storageThrows = false, withToc = true } = {}) {
+  const { document } = parseHTML(`<!doctype html><html><body>
+    <article>
+      <header>
+        <button class="toc-toggle" aria-expanded="false" aria-controls="toc">
+          <span class="visually-hidden">Inhoudsopgave tonen</span>
+        </button>
+      </header>
+    </article>
+    ${withToc ? '<aside id="toc" class="toc" aria-label="Op deze pagina"></aside>' : ''}
+  </body></html>`)
+
+  const store = { 'toc-open': stored }
+  const localStorage = {
+    getItem(key) {
+      if (storageThrows) throw new Error('localStorage geblokkeerd')
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null
+    },
+  }
+
+  // Het script is een plain browser-IIFE: draaien met document/localStorage
+  // als parameters i.p.v. globals, zodat tests elkaar niet beinvloeden.
+  new Function('document', 'localStorage', src)(document, localStorage)
+  return document
+}
+
+test('zonder opgeslagen voorkeur: TOC open en toggle-status in sync', () => {
+  const doc = setup({ stored: null })
+  const toc = doc.getElementById('toc')
+  const toggle = doc.querySelector('.toc-toggle')
+
+  assert.ok(toc.classList.contains('is-open'))
+  assert.equal(toggle.getAttribute('aria-expanded'), 'true')
+  assert.equal(toggle.querySelector('.visually-hidden').textContent, 'Inhoudsopgave verbergen')
+})
+
+test('opgeslagen voorkeur "false": TOC blijft dicht (thema-status ongemoeid)', () => {
+  const doc = setup({ stored: 'false' })
+  const toggle = doc.querySelector('.toc-toggle')
+
+  assert.equal(doc.getElementById('toc').classList.contains('is-open'), false)
+  assert.equal(toggle.getAttribute('aria-expanded'), 'false')
+  assert.equal(toggle.querySelector('.visually-hidden').textContent, 'Inhoudsopgave tonen')
+})
+
+test('opgeslagen voorkeur "true": het thema heeft al geopend, wij raken niets aan', () => {
+  const doc = setup({ stored: 'true' })
+  // Het thema zet is-open zelf; ons script mag die status niet dupliceren of
+  // terugdraaien. Hier staat de aside nog dicht, dus "niets doen" is zichtbaar.
+  assert.equal(doc.getElementById('toc').classList.contains('is-open'), false)
+})
+
+test('geblokkeerde localStorage: valt terug op standaard open', () => {
+  const doc = setup({ storageThrows: true })
+  assert.ok(doc.getElementById('toc').classList.contains('is-open'))
+})
+
+test('pagina zonder TOC: geen fout', () => {
+  assert.doesNotThrow(() => setup({ withToc: false }))
+})


### PR DESCRIPTION
## Beschrijving

Punten 1 t/m 4 uit de navigatie/UI-review. Drie ervan gaan over dezelfde aside ("Op deze pagina"), de vierde staat los.

### 1. TOC onbereikbaar onder 950px

Het thema zet `.toc` standaard dicht (`opacity/visibility/max-height` op 0 in `layout.css`) en toont de toggle pas vanaf 950px (`button.toc-toggle { display: none }`, `@media (min-width: 950px) { display: flex }`). Onder die breedte was de inhoudsopgave dus niet te openen — op `/samenhang/`, de onderwerp- en de over-pagina's bleef die permanent onzichtbaar.

### 2. Normpagina vocht tegen het thema

`layouts/normen/single.html` zette een hardgecodeerde `is-open`-class op de aside — bewust, uit de feedbackronde in `ac5c38e` ("`is-open` wordt expliciet meegegeven omdat de `.toc` default hidden is"). Maar de toggle bleef op `aria-expanded="false"` staan met label "Inhoudsopgave tonen". Gevolg: een screenreader meldde "ingeklapt" bij een zichtbare lijst, en `localStorage['toc-open'] === "false"` werd genegeerd — sloot je de TOC elders, dan stond die op elke normpagina weer open.

De intentie (TOC open) blijft; alleen de uitvoering verhuist naar `assets/js/toc-default-open.js`. Dat draait als laatste in de themabundel, dus ná `theme/js/toc.js`, en grijpt alléén in als de gebruiker nog géén voorkeur heeft opgeslagen. Daarmee geldt standaard-open nu site-breed in plaats van alleen op normpagina's, en klopt de toggle-status.

Om dat script op elke pagina te laden shadowt dit project `layouts/_partials/scripts.html`. De bundel-lijst daarin is een kopie van het thema; er staat een expliciete waarschuwing bij om die bij `just update-theme` te controleren.

### 3. TOC en PDF-knop onderaan op smalle schermen

Het tweekolomsgrid geldt alleen vanaf 950px. Daaronder valt de aside ná het artikel, dus stonden de inhoudsopgave én "Download als PDF" onder een volledige normpagina. Onder 950px staat de aside nu boven het artikel (`order: -1`), en `position: sticky` gaat daar uit — zonder eigen kolom heeft dat geen functie.

### 4. Lege taxonomie-pagina's

`/tags/` en `/categories/` werden gegenereerd, waren leeg, hadden nul inkomende links en stonden wél in `sitemap.xml`. `disableKinds: [taxonomy, term]` in `hugo.yaml`.

## Type wijziging

- [x] Bug fix
- [ ] Nieuwe feature
- [ ] Inhoudelijke correctie (norm-content)
- [ ] Refactor
- [ ] Documentatie
- [ ] CI / build / infra

## Test plan

- [x] `npm test` — 20/20 groen, inclusief vijf nieuwe tests voor `toc-default-open.js` (geen voorkeur → open + aria in sync; `"false"` → blijft dicht; `"true"` → thema doet het, wij niet; geblokkeerde `localStorage`; pagina zonder TOC)
- [x] `pre-commit run --all-files` — alles Passed
- [x] Productiebuild geverifieerd: geen `tags/`- of `categories/`-map, geen van beide in de sitemap, aside rendert als `<aside id="toc" class="toc">` met `aria-expanded="false"`, en ons script staat in de bundel ná `theme/js/toc.js`
- [ ] Handmatig op de preview: normpagina op desktop (TOC open, uitklappen onthouden na herladen) en op mobiel (TOC + downloadknop boven de tekst, toggle werkt); `/samenhang/` op mobiel

De laatste stap vraagt een browser — die kan ik hier niet draaien, dus die staat open.

## Upstream-kandidaten voor het thema

- `.toc` een `toc_default_open`-param geven, zodat het shadowen van `scripts.html` niet nodig is.
- De toggle ook onder 950px tonen, of de TOC daar als inklapbaar blok bovenaan renderen.

## Inhoudelijke afstemming

_N.v.t. — geen norm-content gewijzigd._

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes
- [x] `CHANGELOG.md` bijgewerkt onder `[Unreleased]`
- [ ] Gerelateerde issues gelinkt