### PR TITLE
fix: navigatie, gebruikersflow en vindbaarheid uit de review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ changelog volgt [Semantic Versioning][semver].
 
 ### Toegevoegd
 
+- Zoekfilters per sectie (Alles / Normen / Onderwerpen / Over) in de
+  zoekmodal.
+- `robots.txt` verwijst naar de sitemap.
+- Eigen 404-pagina met de vier ingangen van het toetsingskader en een
+  verwijzing naar de zoekfunctie, in plaats van alleen een link naar de
+  homepage.
 - Pagina "Samenhang van de normen" (`/samenhang/`) met het bollendiagram, de
   uitleg over richten/verrichten en de relatie met DUTO. Bevat een
   placeholder voor de nog te leveren procesplaat.
@@ -23,6 +29,20 @@ changelog volgt [Semantic Versioning][semver].
 
 ### Gewijzigd
 
+- Navigatie: de secties staan nu in een tweede navigatiebalk die per sectie de
+  onderliggende pagina's uitklapt. Vanaf een normpagina zijn de andere zeven
+  normen direct bereikbaar. De breadcrumb vervalt daarmee (het thema toont die
+  niet naast een sectiebalk).
+- De inhoudsopgave op een normpagina gaat nu tot voorschriftniveau, met
+  dezelfde nummering als de body.
+- Elke norm heeft een "Zie ook" met verwijzingen naar de begrippen uit de
+  index; voorheen verwezen alleen de begrippen naar de normen.
+- Het woord "onderwerp" is gereserveerd voor de begrippenindex. Op `/normen/`
+  en in het diagrambijschrift heet het nu "normen", en bij DUTO "kenmerken".
+- De zichtbare `[PLACEHOLDER: …]`-teksten in de nog niet uitgewerkte normen
+  zijn vervangen door tekst die zegt dat de uitwerking volgt, met een callout
+  onder Normuitleg.
+- Begrippagina's hebben geen inhoudsopgave meer (die bevatte één regel).
 - Normen hernoemd zodat bestandsnaam, `norm_id` en `norm_titel` overeenkomen
   met de volgorde uit de introductie van het toetsingskader:
   `03-ordeningsstructuur` → `03-ordenen`, `04-metadatering` →
@@ -71,6 +91,15 @@ changelog volgt [Semantic Versioning][semver].
   (geen lege of op-een-leesteken-geplaatste hover-term meer); een term die
   tegelijk een interne link is, wordt blauw met de voetnoot-stippellijn.
 - Zoek-highlight knipt links in de paginatekst niet meer op.
+- Het bollendiagram had `role="img"`, waardoor hulpsoftware de acht normlinks
+  erin niet aanbood. "Gecontroleerd vernietigen" was op de samenhangpagina
+  bovendien alleen via het diagram te bereiken; die norm staat nu ook in de
+  lopende tekst.
+- `/over/doel/`, `/over/doelgroep/` en `/samenhang/` hadden geen enkele
+  uitgaande verwijzing meer aan het eind van de pagina.
+- De A-Z index en de vorige/volgende-navigatie van de begrippen sorteerden op
+  verschillende velden (titel versus weight) en konden uit elkaar lopen; elk
+  begrip heeft nu een weight die de alfabetische rang volgt.
 - "Op deze pagina"-TOC volgt de actieve sectie nu vloeiend mee; voorheen
   verdween de highlight in de voorschrift-/criteria-/indicator-blokken
   (project-scroll-spy; thema-fix als upstream-PR ingediend).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ changelog volgt [Semantic Versioning][semver].
 ### Toegevoegd
 
 - Zoekfilters per sectie (Alles / Normen / Onderwerpen / Over) in de
-  zoekmodal.
+  zoekmodal. De sectie-indexen (`/normen/`, `/onderwerpen/`, `/over/`) staan
+  nu ook in de zoekindex; hun introteksten waren daarvoor niet te vinden.
 - `robots.txt` verwijst naar de sitemap.
 - Eigen 404-pagina met de vier ingangen van het toetsingskader en een
   verwijzing naar de zoekfunctie, in plaats van alleen een link naar de
@@ -29,10 +30,6 @@ changelog volgt [Semantic Versioning][semver].
 
 ### Gewijzigd
 
-- Navigatie: de secties staan nu in een tweede navigatiebalk die per sectie de
-  onderliggende pagina's uitklapt. Vanaf een normpagina zijn de andere zeven
-  normen direct bereikbaar. De breadcrumb vervalt daarmee (het thema toont die
-  niet naast een sectiebalk).
 - De inhoudsopgave op een normpagina gaat nu tot voorschriftniveau, met
   dezelfde nummering als de body.
 - Elke norm heeft een "Zie ook" met verwijzingen naar de begrippen uit de

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -43,11 +43,14 @@
   text-decoration: none;
 }
 
+/* Tekst op de brand-vlakken via `--color-text-on-primary`, niet hardcoded #fff:
+   in dark mode is `--color-primary` hemelblauw (#80d5fc) en zou witte tekst
+   onleesbaar zijn (~1,3:1). Het thema-token schakelt mee naar donkere tekst. */
 .index-letters a:hover,
 .index-letters a:focus-visible {
   background-color: var(--color-primary);
   border-color: var(--color-primary);
-  color: #fff;
+  color: var(--color-text-on-primary);
 }
 
 .index-group h2 {
@@ -147,14 +150,14 @@
   gap: 0.5em;
   background-color: var(--color-primary);
   border-color: var(--color-primary);
-  color: #fff;
+  color: var(--color-text-on-primary);
 }
 
 .pdf-download.button:hover,
 .pdf-download.button:focus-visible {
   background-color: var(--color-primary);
   border-color: var(--color-primary);
-  color: #fff;
+  color: var(--color-text-on-primary);
   filter: brightness(0.9);
 }
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,11 +2,6 @@
 layout: hero
 title: "Toetsingskader Archiefwet"
 description: "Hoe de Inspectie Overheidsinformatie en Erfgoed toezicht houdt op de naleving van de Archiefwet 2026."
-# Zet de tweede navigatiebalk (het `sections`-menu) op élke pagina aan; het
-# thema leest `second_nav` van de pagina, en een cascade vanaf de homepage
-# geldt sitebreed.
-cascade:
-  second_nav: sections
 hero:
   image: "images/hero.png"
   image_alt: "Toetsingskader Archiefwet"

--- a/content/_index.md
+++ b/content/_index.md
@@ -2,6 +2,11 @@
 layout: hero
 title: "Toetsingskader Archiefwet"
 description: "Hoe de Inspectie Overheidsinformatie en Erfgoed toezicht houdt op de naleving van de Archiefwet 2026."
+# Zet de tweede navigatiebalk (het `sections`-menu) op élke pagina aan; het
+# thema leest `second_nav` van de pagina, en een cascade vanaf de homepage
+# geldt sitebreed.
+cascade:
+  second_nav: sections
 hero:
   image: "images/hero.png"
   image_alt: "Toetsingskader Archiefwet"

--- a/content/normen/01-beheer.md
+++ b/content/normen/01-beheer.md
@@ -173,6 +173,8 @@ Alle documenten moeten in beheer zijn. Ook de documenten die op elk moment mogen
 - [Overzicht](/normen/02-overzicht/)
 - [Ordening](/normen/03-ordenen/)
 - [Kwaliteitssysteem / periodieke evaluatie](/normen/08-periodieke-evaluatie/)
+- [Document]({{< relref "/onderwerpen/document" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})
 
 
 [^aw-artikel-4-1-lid-1]: Aw, artikel 4.1, lid 1. [Bekijk bron](https://zoek.officielebekendmakingen.nl/kst-35968-2.html)

--- a/content/normen/02-overzicht.md
+++ b/content/normen/02-overzicht.md
@@ -30,3 +30,8 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/02-overzicht.md
+++ b/content/normen/02-overzicht.md
@@ -5,31 +5,35 @@ weight: 2
 norm_id: "2"
 norm_titel: "Overzicht"
 kern: "De organisatie heeft een overzicht van welke documenten (d.w.z. papieren en digitale stukken, waaronder e-mail, overheidsinformatie in databases, overheidsinformatie op websites of overheidsinformatie op sociale media kanalen) ze onder zich heeft en waar die zich bevindt."
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in][^aw-artikel-4-1-lid-1]
+De wettelijke grondslag voor deze norm staat in de Archiefwet- en regelgeving.[^aw-artikel-4-1-lid-1] De toelichting wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 [^aw-artikel-4-1-lid-1]: AW, artikel 4.1, lid 1. [Bekijk bron](https://zoek.officielebekendmakingen.nl/kst-35968-2.html)
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/03-ordenen.md
+++ b/content/normen/03-ordenen.md
@@ -7,31 +7,35 @@ norm_titel: "Ordenen"
 aliases:
   - /normen/03-ordeningsstructuur/
 kern: "Documenten zijn gekoppeld aan een ordening. Een ordeningsstructuur is een onmisbaar instrument voor het beheer van documenten."
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in][^ab-artikel-2-1-lid-1]
+De wettelijke grondslag voor deze norm staat in de Archiefwet- en regelgeving.[^ab-artikel-2-1-lid-1] De toelichting wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 [^ab-artikel-2-1-lid-1]: AB, artikel 2.1, lid 1. [Bekijk bron](https://www.internetconsultatie.nl/archiefbesluit20xx/b1)
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/03-ordenen.md
+++ b/content/normen/03-ordenen.md
@@ -32,3 +32,10 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Classificatie en aggregatie]({{< relref "/onderwerpen/classificatie-en-aggregatie" >}})
+- [Samenhang en interpreteerbaarheid]({{< relref "/onderwerpen/samenhang-en-interpreteerbaarheid" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/04-metadateren.md
+++ b/content/normen/04-metadateren.md
@@ -7,31 +7,35 @@ norm_titel: "Metadateren"
 aliases:
   - /normen/04-metadatering/
 kern: "Documenten zijn gemetadateerd zodat hun onderlinge samenhang bekend is, hun betrouwbaarheid kan worden aangetoond, gevonden kunnen worden, opgenomen kunnen worden in een overzicht, toekomstbestendig worden gehouden en geselecteerd kunnen worden voor gecontroleerde vernietiging."
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in][^ab-artikel-2-1-lid-1]
+De wettelijke grondslag voor deze norm staat in de Archiefwet- en regelgeving.[^ab-artikel-2-1-lid-1] De toelichting wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 [^ab-artikel-2-1-lid-1]: Ab, artikel 2.1, lid 1, sub f en artikel 2.2, 2.3 en 2.4. [Bekijk bron](https://www.internetconsultatie.nl/archiefbesluit20xx/b1)
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/04-metadateren.md
+++ b/content/normen/04-metadateren.md
@@ -32,3 +32,13 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Audittrail]({{< relref "/onderwerpen/audittrail" >}})
+- [Classificatie en aggregatie]({{< relref "/onderwerpen/classificatie-en-aggregatie" >}})
+- [Metadata: hardware en programmatuur]({{< relref "/onderwerpen/metadata-hardware-en-programmatuur" >}})
+- [Metadata: integriteitscheck]({{< relref "/onderwerpen/metadata-integriteitscheck" >}})
+- [Samenhang en interpreteerbaarheid]({{< relref "/onderwerpen/samenhang-en-interpreteerbaarheid" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/05-betrouwbaar.md
+++ b/content/normen/05-betrouwbaar.md
@@ -7,31 +7,35 @@ norm_titel: "Informatiebeveiliging en betrouwbaar"
 aliases:
   - /normen/06-vernietigen/
 kern: "Een document moet aantoonbaar betrouwbaar zijn, dat wil zeggen dat het document is, wat het zegt te zijn."
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in][^ar-artikel-2-3]
+De wettelijke grondslag voor deze norm staat in de Archiefwet- en regelgeving.[^ar-artikel-2-3] De toelichting wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 [^ar-artikel-2-3]: Ar, artikel 2.3. [Bekijk bron](https://www.internetconsultatie.nl/archiefregeling/b1)
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/05-betrouwbaar.md
+++ b/content/normen/05-betrouwbaar.md
@@ -32,3 +32,12 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Audittrail]({{< relref "/onderwerpen/audittrail" >}})
+- [Hashfunctie]({{< relref "/onderwerpen/hashfunctie" >}})
+- [Incidenten voorkomen]({{< relref "/onderwerpen/incidenten-voorkomen" >}})
+- [Metadata: integriteitscheck]({{< relref "/onderwerpen/metadata-integriteitscheck" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/06-vindbaar.md
+++ b/content/normen/06-vindbaar.md
@@ -32,3 +32,8 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/06-vindbaar.md
+++ b/content/normen/06-vindbaar.md
@@ -7,31 +7,35 @@ norm_titel: "Vindbaar"
 aliases:
   - /normen/05-vindbaarheid/
 kern: "Een document moet binnen een redelijke termijn na creatie of ontvangst vindbaar, beschikbaar en leesbaar zijn."
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in][^ar-artikel-2-2]
+De wettelijke grondslag voor deze norm staat in de Archiefwet- en regelgeving.[^ar-artikel-2-2] De toelichting wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 [^ar-artikel-2-2]: Ar, artikel 2.2. [Bekijk bron](https://www.internetconsultatie.nl/archiefregeling/b1)
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/07-vernietigen.md
+++ b/content/normen/07-vernietigen.md
@@ -7,31 +7,35 @@ norm_titel: "Gecontroleerd vernietigen"
 aliases:
   - /normen/07-informatiebeveiliging/
 kern: "Documenten moeten gecontroleerd vernietigd worden."
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in][^ar-artikel-2-5]
+De wettelijke grondslag voor deze norm staat in de Archiefwet- en regelgeving.[^ar-artikel-2-5] De toelichting wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 [^ar-artikel-2-5]: Ar, artikel 2.5. [Bekijk bron](https://www.internetconsultatie.nl/archiefregeling/b1)
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/07-vernietigen.md
+++ b/content/normen/07-vernietigen.md
@@ -32,3 +32,10 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Aangrijpingspunt]({{< relref "/onderwerpen/aangrijpingspunt" >}})
+- [Incidenten voorkomen]({{< relref "/onderwerpen/incidenten-voorkomen" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/08-periodieke-evaluatie.md
+++ b/content/normen/08-periodieke-evaluatie.md
@@ -28,3 +28,9 @@ synoniemen:
 #### Indicatoren
 
 *Bij dit voorschrift zijn geen indicatoren.*
+
+## Zie ook
+
+- [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}})
+- [Planning- en controlcyclus]({{< relref "/onderwerpen/planning-en-controlcyclus" >}})
+- [Passende maatregelen en risicobenadering]({{< relref "/onderwerpen/passende-maatregelen" >}})

--- a/content/normen/08-periodieke-evaluatie.md
+++ b/content/normen/08-periodieke-evaluatie.md
@@ -4,30 +4,34 @@ versie: "0.8"
 weight: 8
 norm_id: "8"
 norm_titel: "Periodieke evaluatie"
-kern: "[PLACEHOLDER: vul kern in]"
-synoniemen:
-  - "[PLACEHOLDER: vul synoniemen in]"
+kern: "De kern van deze norm wordt in een volgende versie van het toetsingskader vastgesteld."
+synoniemen: []
 ---
 
 ## Toelichting
 
-[PLACEHOLDER: vul toelichting in]
+De toelichting bij deze norm wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 ## Normuitleg
 
-### [PLACEHOLDER: vul thema in]
+{{< callout titel="Nog in bewerking" variant="muted" >}}
+De normuitleg bij deze norm is nog niet vastgesteld. Voorschrift, criteria en
+indicatoren worden in een volgende versie van het toetsingskader uitgewerkt.
+{{< /callout >}}
+
+### Nog uit te werken
 
 #### Voorschrift
 
-[PLACEHOLDER: vul voorschrift in]
+Wordt in een volgende versie van het toetsingskader uitgewerkt.
 
 #### Criteria
 
-*Bij dit voorschrift zijn geen aanvullende criteria.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 #### Indicatoren
 
-*Bij dit voorschrift zijn geen indicatoren.*
+*Worden in een volgende versie van het toetsingskader uitgewerkt.*
 
 ## Zie ook
 

--- a/content/normen/_index.md
+++ b/content/normen/_index.md
@@ -12,7 +12,7 @@ cascade:
   show_referenties: true
 ---
 
-De Inspectie toetst of een document in beheer is, zodat het duurzaam toegankelijk gemaakt en gehouden kan worden. Hieronder staan de onderwerpen die de Inspectie als fundamenteel beschouwt voor de duurzame toegankelijkheid van overheidsinformatie. Zie [de samenhang van de normen]({{< relref "/samenhang" >}}) voor hoe zij zich tot elkaar verhouden.
+De Inspectie toetst of een document in beheer is, zodat het duurzaam toegankelijk gemaakt en gehouden kan worden. Hieronder staan de normen die de Inspectie als fundamenteel beschouwt voor de duurzame toegankelijkheid van overheidsinformatie. Zie [de samenhang van de normen]({{< relref "/samenhang" >}}) voor hoe zij zich tot elkaar verhouden.
 
 {{< pdf-kader >}}
 

--- a/content/normen/_index.md
+++ b/content/normen/_index.md
@@ -9,7 +9,6 @@ manual_layout: true
 wide: true
 cascade:
   show_lastmod: true
-  show_referenties: true
 ---
 
 De Inspectie toetst of een document in beheer is, zodat het duurzaam toegankelijk gemaakt en gehouden kan worden. Hieronder staan de normen die de Inspectie als fundamenteel beschouwt voor de duurzame toegankelijkheid van overheidsinformatie. Zie [de samenhang van de normen]({{< relref "/samenhang" >}}) voor hoe zij zich tot elkaar verhouden.

--- a/content/onderwerpen/_index.md
+++ b/content/onderwerpen/_index.md
@@ -7,6 +7,9 @@ prev_next: true
 show_lastmod: true
 cascade:
   show_lastmod: true
+  # Begrippagina's zijn kort en hebben hooguit één kop ("Zie ook"); een
+  # inhoudsopgave met één regel is ruis. Het thema respecteert `toc: false`.
+  toc: false
 ---
 
 Deze index geeft toegang tot de begrippen die in het toetsingskader worden gebruikt. Elk begrip is los te lezen en wordt vanuit de normpagina's aangehaald. De index wordt stapsgewijs aangevuld met trefwoorden uit de normen.

--- a/content/onderwerpen/aangrijpingspunt.md
+++ b/content/onderwerpen/aangrijpingspunt.md
@@ -2,6 +2,7 @@
 title: "Aangrijpingspunt"
 card_title: "Aangrijpingspunt"
 description: "Het moment waarop de telling van een bewaartermijn of overbrengingstermijn begint."
+weight: 10
 synoniemen:
   - "Startmoment bewaartermijn"
   - "Overbrengingstermijn"

--- a/content/onderwerpen/audittrail.md
+++ b/content/onderwerpen/audittrail.md
@@ -2,6 +2,7 @@
 title: "Audittrail"
 card_title: "Audittrail"
 description: "Chronologische registratie van activiteiten en transacties bij een document, waarmee reconstructie en onderzoek mogelijk is."
+weight: 20
 synoniemen:
   - "Logging"
   - "Auditlog"

--- a/content/onderwerpen/classificatie-en-aggregatie.md
+++ b/content/onderwerpen/classificatie-en-aggregatie.md
@@ -2,6 +2,7 @@
 title: "Classificatie en aggregatie"
 card_title: "Classificatie en aggregatie"
 description: "Documenten die bij elkaar horen vormen samen een aggregatie, bijvoorbeeld een zaak, dossier, serie of deelarchief."
+weight: 30
 synoniemen:
   - "Aggregatieniveau"
   - "Dossier"

--- a/content/onderwerpen/document.md
+++ b/content/onderwerpen/document.md
@@ -2,6 +2,7 @@
 title: "Document"
 card_title: "Document"
 description: "Wat de Archiefwet onder een document verstaat, en waarom dat begrip samenvalt met informatieobject en overheidsinformatie."
+weight: 40
 synoniemen:
   - "Informatie-object"
   - "Informatieobject"

--- a/content/onderwerpen/hashfunctie.md
+++ b/content/onderwerpen/hashfunctie.md
@@ -2,6 +2,7 @@
 title: "Hashfunctie"
 card_title: "Hashfunctie"
 description: "Techniek waarmee de blijvende integriteit van digitale bestanden geautomatiseerd controleerbaar wordt gemaakt."
+weight: 50
 synoniemen:
   - "Hash"
   - "Checksum"

--- a/content/onderwerpen/incidenten-voorkomen.md
+++ b/content/onderwerpen/incidenten-voorkomen.md
@@ -2,6 +2,7 @@
 title: "Incidenten voorkomen"
 card_title: "Incidenten voorkomen"
 description: "Risico's als hacks, virussen en gijzelsoftware kunnen leiden tot informatieverlies en onrechtmatige vernietiging."
+weight: 60
 synoniemen:
   - "Beveiligingsincident"
   - "Gijzelsoftware"

--- a/content/onderwerpen/metadata-hardware-en-programmatuur.md
+++ b/content/onderwerpen/metadata-hardware-en-programmatuur.md
@@ -2,6 +2,7 @@
 title: "Metadata: hardware en programmatuur"
 card_title: "Metadata: hardware en programmatuur"
 description: "Bij documenten die langer dan tien jaar worden bewaard moet de gebruikte hardware, besturings- en toepassingsprogrammatuur zijn vastgelegd."
+weight: 70
 synoniemen:
   - "Besturingsprogrammatuur"
   - "Toepassingsprogrammatuur"

--- a/content/onderwerpen/metadata-integriteitscheck.md
+++ b/content/onderwerpen/metadata-integriteitscheck.md
@@ -2,6 +2,7 @@
 title: "Metadata: integriteitscheck"
 card_title: "Metadata: integriteitscheck"
 description: "Bij documenten die langer dan tien jaar worden bewaard moeten de resultaten van integriteitschecks in de metadata staan."
+weight: 80
 synoniemen:
   - "Integriteitscheck"
   - "Integriteitscontrole"

--- a/content/onderwerpen/passende-maatregelen.md
+++ b/content/onderwerpen/passende-maatregelen.md
@@ -2,6 +2,7 @@
 title: "Passende maatregelen en risicobenadering"
 card_title: "Passende maatregelen en risicobenadering"
 description: "Wat passende maatregelen zijn, en hoe een risicobenadering ruimte biedt voor maatwerk binnen de wettelijke normen."
+weight: 90
 # Geen weight: onderwerpen sorteren alfabetisch op titel, zowel in de A-Z-index
 # als in de vorige/volgende-navigatie (page-nav sorteert ByWeight, en met
 # gelijke weights valt Hugo terug op de titel).

--- a/content/onderwerpen/passende-maatregelen.md
+++ b/content/onderwerpen/passende-maatregelen.md
@@ -2,10 +2,10 @@
 title: "Passende maatregelen en risicobenadering"
 card_title: "Passende maatregelen en risicobenadering"
 description: "Wat passende maatregelen zijn, en hoe een risicobenadering ruimte biedt voor maatwerk binnen de wettelijke normen."
+# Weight volgt de alfabetische rang (10, 20, 30, …): de A-Z-index sorteert op
+# titel, de vorige/volgende-navigatie van het thema op weight. Zonder die
+# afspraak lopen index en carousel uit elkaar.
 weight: 90
-# Geen weight: onderwerpen sorteren alfabetisch op titel, zowel in de A-Z-index
-# als in de vorige/volgende-navigatie (page-nav sorteert ByWeight, en met
-# gelijke weights valt Hugo terug op de titel).
 aliases:
   - /over/passende-maatregelen/
   - /over/passende-maatregelen-en-risicobenadering/

--- a/content/onderwerpen/planning-en-controlcyclus.md
+++ b/content/onderwerpen/planning-en-controlcyclus.md
@@ -2,6 +2,7 @@
 title: "Planning- en controlcyclus"
 card_title: "Planning- en controlcyclus"
 description: "Archiefbeheer als onderdeel van een breder informatiebeheerbeleid, in samenhang met privacy en informatiebeveiliging."
+weight: 100
 synoniemen:
   - "P&C-cyclus"
   - "Planning en control"

--- a/content/onderwerpen/samenhang-en-interpreteerbaarheid.md
+++ b/content/onderwerpen/samenhang-en-interpreteerbaarheid.md
@@ -2,6 +2,7 @@
 title: "Samenhang en interpreteerbaarheid"
 card_title: "Samenhang en interpreteerbaarheid"
 description: "Metadata over herkomst, context en status maken documenten interpreteerbaar en houden de samenhang met andere documenten zichtbaar."
+weight: 110
 synoniemen:
   - "Interpreteerbaar"
   - "Context"

--- a/content/over/_index.md
+++ b/content/over/_index.md
@@ -14,6 +14,6 @@ cascade:
 
 In dit toetsingskader werkt de Inspectie Overheidsinformatie en Erfgoed uit hoe zij invulling geeft aan haar toezicht op de naleving van de Archiefwet. Het toetsingskader richt zich op de belangrijkste risico's als gevolg van onvoldoende naleving van wet- en regelgeving. Daardoor staan niet alle normen uit de wet- en regelgeving in dit toetsingskader.
 
-Hieronder staat per onderwerp de achtergrond bij het toetsingskader. Wilt u zien hoe de onderwerpen met elkaar samenhangen? Bekijk dan [de samenhang van de normen]({{< relref "/samenhang" >}}).
+Hieronder staat de achtergrond bij het toetsingskader. Wilt u zien hoe de normen met elkaar samenhangen? Bekijk dan [de samenhang van de normen]({{< relref "/samenhang" >}}).
 
 {{< card-grid section="/over" >}}

--- a/content/over/_index.md
+++ b/content/over/_index.md
@@ -1,9 +1,13 @@
 ---
 title: "Over het toetsingskader"
 card_title: "Over het toetsingskader"
-description: "Achtergrond bij het toetsingskader: inleiding, doel, wettelijk kader, opbouw, doelgroep en passende maatregelen."
+description: "Achtergrond bij het toetsingskader: inleiding, doel, wettelijk kader, opbouw en doelgroep."
 weight: 4
+prev_next: true
 show_lastmod: true
+# manual_layout zodat het thema article.html gebruikt (zoals bij de normen);
+# die rendert de vorige/volgende-navigatie, wat de list-variant niet doet.
+manual_layout: true
 cascade:
   show_lastmod: true
 ---
@@ -11,3 +15,5 @@ cascade:
 In dit toetsingskader werkt de Inspectie Overheidsinformatie en Erfgoed uit hoe zij invulling geeft aan haar toezicht op de naleving van de Archiefwet. Het toetsingskader richt zich op de belangrijkste risico's als gevolg van onvoldoende naleving van wet- en regelgeving. Daardoor staan niet alle normen uit de wet- en regelgeving in dit toetsingskader.
 
 Hieronder staat per onderwerp de achtergrond bij het toetsingskader. Wilt u zien hoe de onderwerpen met elkaar samenhangen? Bekijk dan [de samenhang van de normen]({{< relref "/samenhang" >}}).
+
+{{< card-grid section="/over" >}}

--- a/content/over/doel.md
+++ b/content/over/doel.md
@@ -13,3 +13,5 @@ Een overheidsorgaan houdt bij de uitoefening van zijn taken en bevoegdheden die 
 - voor een ieder bij het kennisnemen van en het uitoefenen van rechten en plichten;
 - voor onderzoek; en
 - als onderdeel van het cultureel erfgoed.
+
+Hoe de Inspectie dat toetst, staat uitgewerkt in [de acht normen]({{< relref "/normen" >}}). Zie [Opbouw en indeling]({{< relref "/over/opbouw-en-indeling" >}}) voor het verschil tussen een voorschrift, een criterium en een indicator.

--- a/content/over/doelgroep.md
+++ b/content/over/doelgroep.md
@@ -18,3 +18,5 @@ Alle organisaties van de centrale overheid vallen onder de werking van de Archie
 - Overige
 
 Het volledige overzicht staat op [Overzicht organisaties met archiefwettelijk toezicht](https://www.inspectie-oe.nl/toezichtvelden/overheidsinformatie/geinspecteerde-instellingen) op de website van de Inspectie.
+
+Valt uw organisatie hieronder? Begin dan bij [Norm 1: Inbeheername en beheer]({{< relref "/normen/01-beheer" >}}); daar staat wat het betekent dat documenten in beheer zijn. Welke documenten dat zijn, staat bij [Wettelijk kader]({{< relref "/over/wettelijk-kader" >}}).

--- a/content/samenhang.md
+++ b/content/samenhang.md
@@ -6,7 +6,7 @@ weight: 2
 show_lastmod: true
 ---
 
-Dat documenten in beheer moeten zijn, is het fundament van het toetsingskader. De norm [Inbeheername en beheer]({{< relref "/normen/01-beheer" >}}) staat daarom in het midden; de andere normen werken uit wat er in een beheerde omgeving geregeld moet zijn.
+Dat documenten in beheer moeten zijn, is het fundament van het toetsingskader. De norm [Inbeheername en beheer]({{< relref "/normen/01-beheer" >}}) staat daarom in het midden; de andere normen — van [Overzicht]({{< relref "/normen/02-overzicht" >}}) tot [Gecontroleerd vernietigen]({{< relref "/normen/07-vernietigen" >}}) — werken uit wat er in een beheerde omgeving geregeld moet zijn.
 
 {{< bollendiagram >}}
 
@@ -30,4 +30,10 @@ Het Nationaal Archief definieert in het [DUTO-raamwerk](https://www.nationaalarc
 
 Dit toetsingskader sluit aan bij die definitie. Een deel van de DUTO-kenmerken is direct als norm uitgewerkt: vindbaar en betrouwbaar. Het begrip toekomstbestendig wordt nader ingevuld aan de hand van de normen uit de Archiefwet 2026 en de daarop gebaseerde regelgeving, onder meer via [Overzicht]({{< relref "/normen/02-overzicht" >}}), [Ordenen]({{< relref "/normen/03-ordenen" >}}) en [Metadateren]({{< relref "/normen/04-metadateren" >}}).
 
-De kenmerken beschikbaar en leesbaar zijn nog niet als afzonderlijke norm uitgewerkt. Die onderwerpen staan vervaagd in het diagram hierboven en worden op een later moment aan het toetsingskader toegevoegd. Zie ook [Opbouw en indeling]({{< relref "/over/opbouw-en-indeling" >}}).
+De kenmerken beschikbaar en leesbaar zijn nog niet als afzonderlijke norm uitgewerkt. Die kenmerken staan vervaagd in het diagram hierboven en worden op een later moment aan het toetsingskader toegevoegd. Zie ook [Opbouw en indeling]({{< relref "/over/opbouw-en-indeling" >}}).
+
+## Verder lezen
+
+- [Alle normen]({{< relref "/normen" >}}) — de acht normen met voorschriften, criteria en indicatoren
+- [Onderwerpen en begrippen]({{< relref "/onderwerpen" >}}) — alfabetische index op de begrippen uit de normen
+- [Over het toetsingskader]({{< relref "/over" >}}) — doel, wettelijk kader, opbouw en doelgroep

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,6 +6,12 @@ title: Toetsingskader Archiefwet
 enableRobotsTXT: true
 enableGitInfo: true
 
+# Geen tags/categories in dit kader; zonder dit genereert Hugo lege
+# /tags/- en /categories/-pagina's die wél in de sitemap belanden.
+disableKinds:
+  - taxonomy
+  - term
+
 outputFormats:
   pdf:
     mediaType: application/json

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -49,6 +49,19 @@ params:
       - normen
       - onderwerpen
       - over
+    # Sectiefilters in de zoekmodal. Zonder deze filters toont een resultaat
+    # alleen titel + fragment, dus zag je niet of een treffer een norm, een
+    # begrip of een achtergrondpagina was. Het eerste item (lege `section`)
+    # is "alles" en staat standaard actief.
+    filters:
+      - section: ""
+        label: "Alles"
+      - section: "normen"
+        label: "Normen"
+      - section: "onderwerpen"
+        label: "Onderwerpen"
+      - section: "over"
+        label: "Over"
   tagline: "Normen voor duurzame toegankelijkheid"
   page_banner:
     type: warning

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -80,19 +80,7 @@ params:
     rechts: "Over deze site"
 
 menus:
-  # De secties staan in de tweede navigatiebalk (`params.second_nav`, gezet via
-  # de cascade in content/_index.md). Die balk klapt per sectie de onderliggende
-  # pagina's uit — vanaf een normpagina zijn de andere zeven normen dan direct
-  # bereikbaar, in plaats van via de index. De hoofdbalk houdt alleen Home over
-  # (plus zoeken en de thema-schakelaar, die het thema daar zelf plaatst).
   main:
-    - name: Home
-      pageRef: /
-      weight: 1
-
-  # LET OP: het thema klapt het eerste item (index 0) nooit uit; Home staat
-  # daarom vooraan.
-  sections:
     - name: Home
       pageRef: /
       weight: 1

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -74,7 +74,19 @@ params:
     rechts: "Over deze site"
 
 menus:
+  # De secties staan in de tweede navigatiebalk (`params.second_nav`, gezet via
+  # de cascade in content/_index.md). Die balk klapt per sectie de onderliggende
+  # pagina's uit — vanaf een normpagina zijn de andere zeven normen dan direct
+  # bereikbaar, in plaats van via de index. De hoofdbalk houdt alleen Home over
+  # (plus zoeken en de thema-schakelaar, die het thema daar zelf plaatst).
   main:
+    - name: Home
+      pageRef: /
+      weight: 1
+
+  # LET OP: het thema klapt het eerste item (index 0) nooit uit; Home staat
+  # daarom vooraan.
+  sections:
     - name: Home
       pageRef: /
       weight: 1

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,24 @@
+{{/* Shadowt het thema-404, dat alleen naar de homepage wijst. Dit kader heeft
+     hernoemde URL's gehad (zie de aliases in de normen-front matter), dus de
+     404 is een reële landingsplek. Beter dan één link terug: de vier ingangen
+     plus de hint dat er een zoekfunctie is. */}}
+{{ define "main" }}
+<section>
+  <h1>Pagina niet gevonden</h1>
+  <p>
+    Deze pagina bestaat niet of is verplaatst. Hieronder staan de ingangen van
+    het toetsingskader. Weet u waar u naar zoekt? Gebruik dan de zoekfunctie
+    rechtsboven, of druk op <kbd>/</kbd>.
+  </p>
+
+  <ul>
+    <li><a href="{{ relURL "normen/" }}">Normen</a> — de acht normen met voorschriften, criteria en indicatoren</li>
+    <li><a href="{{ relURL "samenhang/" }}">Samenhang van de normen</a> — hoe de normen zich tot elkaar verhouden</li>
+    <li><a href="{{ relURL "onderwerpen/" }}">Onderwerpen en begrippen</a> — alfabetische index op de begrippen</li>
+    <li><a href="{{ relURL "over/" }}">Over het toetsingskader</a> — doel, wettelijk kader, opbouw en doelgroep</li>
+  </ul>
+
+  <p>Of ga terug naar de <a href="{{ relURL "/" }}">homepage</a>.</p>
+  <p><small>Foutcode: 404</small></p>
+</section>
+{{ end }}

--- a/layouts/_default/list.pdf.json
+++ b/layouts/_default/list.pdf.json
@@ -9,7 +9,7 @@
       "norm_id" (string .Params.norm_id)
       "slug" .File.ContentBaseName
       "kern_html" $kern
-      "body_html" .Content) -}}
+      "body_html" (partial "nummer-voorschriften.html" (dict "content" .Content "norm_id" .Params.norm_id))) -}}
 {{- end -}}
 {{- dict
   "kind" "kader"

--- a/layouts/_default/single.pdf.json
+++ b/layouts/_default/single.pdf.json
@@ -7,7 +7,7 @@
   "norm_id" (string .Params.norm_id)
   "norm_titel" .Params.norm_titel
   "kern_html" $kern
-  "body_html" .Content
+  "body_html" (partial "nummer-voorschriften.html" (dict "content" .Content "norm_id" .Params.norm_id))
   "url" .Permalink
   "versie" (site.Params.versie | default "")
   | jsonify -}}

--- a/layouts/_partials/nummer-voorschriften.html
+++ b/layouts/_partials/nummer-voorschriften.html
@@ -1,0 +1,16 @@
+{{- /*
+  Nummert de "Voorschrift"-koppen in een gerenderde norm-body als
+  "Voorschrift <norm_id>.<n>", sequentieel binnen de norm. Elke replaceRE met
+  limit 1 pakt het eerstvolgende nog-ongenummerde voorschrift.
+
+  Zowel de HTML-pagina als de PDF-output gebruiken dit, zodat de nummering in
+  de PDF gelijk is aan die op de webpagina.
+
+  Aanroep: {{ partial "nummer-voorschriften.html" (dict "content" .Content "norm_id" .Params.norm_id) }}
+*/ -}}
+{{- $content := .content -}}
+{{- $normId := .norm_id -}}
+{{- range $i, $_ := (findRE `<h4 id="voorschrift[^"]*">Voorschrift</h4>` $content) -}}
+  {{- $content = replaceRE `(<h4 id="voorschrift[^"]*">)Voorschrift(</h4>)` (printf `${1}Voorschrift %v.%d${2}` $normId (add $i 1)) $content 1 -}}
+{{- end -}}
+{{- return $content -}}

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -23,11 +23,15 @@
   {{- if and .Params.norm_id .Params.norm_titel -}}
     {{- $title = printf "Norm %s: %s" (string .Params.norm_id) .Params.norm_titel -}}
   {{- end -}}
+  {{- /* Géén apart `synoniemen`-veld: de zoek-JS van het thema indexeert
+         alleen `title` en `content`, dus dat veld was dode ballast die de
+         synoniemen dubbel in de index zette. Ze zitten hierboven al in
+         `$text`. Zodra het thema een eigen sleutel voor synoniemen krijgt,
+         kan het veld terug. */ -}}
   {{- $pages = $pages | append (dict
     "title" $title
     "url" .RelPermalink
     "section" $section
-    "synoniemen" $synoniemen
     "content" $text
   ) -}}
 {{- end -}}

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -3,7 +3,11 @@
        matter en `synoniemen` worden bewust niet getoond maar wel
        geïndexeerd. `markdownify | plainify` maakt er platte tekst van. */ -}}
 {{- $pages := slice -}}
-{{- $allPages := site.RegularPages | append site.Home -}}
+{{- /* Sectie-indexen (`_index.md`) zitten niet in `site.RegularPages`, maar
+       hebben wel eigen tekst die vindbaar moet zijn: /normen/ legt voorschrift/
+       criterium/indicator uit, /over/ en /onderwerpen/ hebben een intro. Toen
+       `content/over.md` een sectie werd, viel die tekst uit de index. */ -}}
+{{- $allPages := site.RegularPages | append (where site.Pages "Kind" "section") | append site.Home -}}
 {{- range $allPages -}}
   {{- $text := .Plain -}}
   {{- with .Params.kern }}{{ $text = printf "%s %s" $text (. | markdownify | plainify) }}{{ end -}}

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -63,13 +63,10 @@
   {{ $content = replaceRE `(?s)<div class="footnotes" role="doc-endnotes">.*?</ol>\s*</div>` "" $content }}
 {{ end }}
 
-{{/* 3. Voorschriften nummeren als "Voorschrift <norm_id>.<n>" (sequentieel
-       binnen de norm; norm_id uit de front matter). Elke replaceRE met limit 1
-       pakt het eerstvolgende nog-ongenummerde voorschrift. */}}
-{{ $normId := .Params.norm_id }}
-{{ range $i, $_ := (findRE `<h4 id="voorschrift[^"]*">Voorschrift</h4>` $content) }}
-  {{ $content = replaceRE `(<h4 id="voorschrift[^"]*">)Voorschrift(</h4>)` (printf `${1}Voorschrift %v.%d${2}` $normId (add $i 1)) $content 1 }}
-{{ end }}
+{{/* 3. Voorschriften nummeren als "Voorschrift <norm_id>.<n>". Gedeeld met de
+       PDF-output (layouts/_default/*.pdf.json), zodat web en PDF dezelfde
+       nummering tonen. */}}
+{{ $content = partial "nummer-voorschriften.html" (dict "content" $content "norm_id" .Params.norm_id) }}
 
 {{/* 4. Toelichting inklapbaar maken (standaard dicht). Het kader is naslag, dus
        criteria/indicatoren moeten snel bereikbaar zijn zonder eerst langs de
@@ -92,7 +89,7 @@
      De labels komen niet uit .Fragments (daar heet elke kop nog "Voorschrift",
      want het nummer wordt pas ná het renderen in de body gezet). Daarom hier
      dezelfde telling: paginabreed, in documentvolgorde — identiek aan wat
-     _partials/nummer-voorschriften.html in de body doet. */}}
+     _partials/nummer-voorschriften.html hierboven in de body doet. */}}
 {{ $vsLabels := dict }}
 {{ $vsCount := 0 }}
 {{ range $headings }}{{ range .Headings }}{{ range .Headings }}

--- a/layouts/normen/single.html
+++ b/layouts/normen/single.html
@@ -84,6 +84,24 @@
 {{ with $headings }}{{ $first := index . 0 }}{{ if not $first.ID }}{{ $headings = $first.Headings }}{{ end }}{{ end }}
 {{ $hasToc := or .Params.kern (gt (len $headings) 0) }}
 
+{{/* Voorschrift-koppen (h4) horen óók in de TOC: de nummering is bedoeld als
+     verwijsanker ("zie voorschrift 1.5"), maar zonder TOC-ingang was zo'n
+     voorschrift alleen met scrollen te vinden. Criteria en Indicatoren blijven
+     eruit, anders slibt de lijst dicht.
+
+     De labels komen niet uit .Fragments (daar heet elke kop nog "Voorschrift",
+     want het nummer wordt pas ná het renderen in de body gezet). Daarom hier
+     dezelfde telling: paginabreed, in documentvolgorde — identiek aan wat
+     _partials/nummer-voorschriften.html in de body doet. */}}
+{{ $vsLabels := dict }}
+{{ $vsCount := 0 }}
+{{ range $headings }}{{ range .Headings }}{{ range .Headings }}
+  {{ if eq .Title "Voorschrift" }}
+    {{ $vsCount = add $vsCount 1 }}
+    {{ $vsLabels = merge $vsLabels (dict .ID (printf "Voorschrift %v.%d" $.Params.norm_id $vsCount)) }}
+  {{ end }}
+{{ end }}{{ end }}{{ end }}
+
 <article class="norm{{ if .Params.wide }} wide{{ end }}">
   <header>
     <h1>{{ .Title }}</h1>
@@ -133,7 +151,18 @@
         <a href="#{{ .ID }}">{{ .Title }}</a>
         {{- with .Headings -}}
         <ul>
-          {{- range . -}}<li><a href="#{{ .ID }}">{{ .Title }}</a></li>{{- end -}}
+          {{- range . -}}
+          <li>
+            <a href="#{{ .ID }}">{{ .Title }}</a>
+            {{- $vs := slice -}}
+            {{- range .Headings -}}{{- if eq .Title "Voorschrift" -}}{{- $vs = $vs | append . -}}{{- end -}}{{- end -}}
+            {{- with $vs -}}
+            <ul>
+              {{- range . -}}<li><a href="#{{ .ID }}">{{ index $vsLabels .ID }}</a></li>{{- end -}}
+            </ul>
+            {{- end -}}
+          </li>
+          {{- end -}}
         </ul>
         {{- end -}}
       </li>

--- a/layouts/onderwerpen/list.html
+++ b/layouts/onderwerpen/list.html
@@ -5,7 +5,12 @@
      index-component krijgt.
 
      Groeperen zonder GroupBy: .Pages.ByTitle staat al alfabetisch, dus de
-     beginletters in leesvolgorde vormen vanzelf de gesorteerde letterlijst. */}}
+     beginletters in leesvolgorde vormen vanzelf de gesorteerde letterlijst.
+
+     LET OP: de vorige/volgende-navigatie (theme _partials/page-nav.html) sorteert
+     op .Pages.ByWeight, niet op titel. Daarom heeft elk begrip een `weight` die
+     de alfabetische rang volgt (10, 20, 30, …), zodat index en carousel niet uit
+     elkaar kunnen lopen. Nieuw begrip ertussen: pak een weight in het gat. */}}
 {{ $pages := .Pages.ByTitle }}
 {{ $letters := slice }}
 {{ range $pages }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,7 @@
+{{/* Hugo's ingebouwde robots.txt is alleen "User-agent: *", zonder verwijzing
+     naar de sitemap. Voor een naslagwerk dat via zoekmachines gevonden moet
+     worden is die verwijzing het minimum. */ -}}
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/layouts/shortcodes/bollendiagram.html
+++ b/layouts/shortcodes/bollendiagram.html
@@ -17,7 +17,11 @@
   <svg class="bollendiagram"
        viewBox="80 0 480 525"
        xmlns="http://www.w3.org/2000/svg"
-       role="img"
+       {{/* Bewust géén role="img": dat maakt de hele SVG één bladknoop, waardoor
+            hulpsoftware de acht normlinks hierin niet meer aanbiedt. Met
+            role="group" blijft de titel de toegankelijke naam én blijven de
+            links bereikbaar. */}}
+       role="group"
        aria-labelledby="bollendiagram-title">
     <title id="bollendiagram-title">Relatie tussen de normen van het Toetsingskader Archiefwet</title>
 
@@ -105,6 +109,6 @@
   </svg>
 
   <figcaption class="bollendiagram-caption">
-    Het toetsingskader bevat nu acht onderwerpen die de inspectie als fundamenteel voor de duurzame toegankelijkheid beschouwt. De norm <a href="{{ relURL "normen/01-beheer/" }}">in beheer</a> vormt de basis; de zeven andere normen hangen daar direct mee samen. De vier vervaagde onderwerpen onderaan horen hier ook bij en worden op een later moment aan het toetsingskader toegevoegd.
+    Het toetsingskader bevat nu acht normen die de Inspectie als fundamenteel voor de duurzame toegankelijkheid beschouwt. De norm <a href="{{ relURL "normen/01-beheer/" }}">in beheer</a> vormt de basis; de zeven andere normen hangen daar direct mee samen. De vier vervaagde kenmerken onderaan (leesbaar, migreren, converteren en beschikbaar) horen hier ook bij en worden op een later moment aan het toetsingskader toegevoegd.
   </figcaption>
 </figure>


### PR DESCRIPTION
## Beschrijving

Verwerkt de bevindingen 5 t/m 23 uit de navigatie/UI/gebruikersflow-review. Basis is `feat/herziening-over-index-procesplaat`, zodat de review-resultaten op dezelfde content landen als waarop ze zijn vastgesteld. Elke bevinding zit in een eigen commit.

De eerste commit legt alleen de openstaande werkkopie van de over-index vast (article-layout + vorige/volgende + card-grid), zodat die los te beoordelen is van de rest.

### Verwijzingen: de normen wisten niet dat de begrippenindex bestond

De begrippen verwezen 23 keer naar een norm, de normen 1 keer terug. Vanaf een normpagina was `/onderwerpen/` niet te bereiken, terwijl de leeswijzer op `/normen/` wél een "Zie ook" met verwijzingen naar onderwerpen aankondigt.

De toegevoegde verwijzingen zijn de **inversie van wat de begrippen zelf al claimen**: elk begrip dat naar een norm linkt, staat nu in de "Zie ook" van die norm. Er is dus geen nieuwe inhoudelijke relatie verzonnen. Daarnaast verwijst elke norm naar Inbeheername en beheer als fundament, in lijn met de bestaande "Zie ook" van norm 1.

### "Onderwerp" betekende drie dingen

De begrippenindex in de navigatie, de normen zelf (op `/normen/` en in het diagrambijschrift) en de DUTO-kenmerken. Nu heet alleen de begrippenindex nog "onderwerpen"; de rest is "normen" respectievelijk "kenmerken".

### Zichtbare placeholders

Zeven van de acht normen toonden `[PLACEHOLDER: vul thema in]` en varianten letterlijk aan de bezoeker — in de body, in de inhoudsopgave, in de zoekindex en in de PDF. Norm 8 had zelfs een placeholder als `kern`, die daardoor op de normen-index en in de kader-PDF stond. Vervangen door tekst die zegt wat er aan de hand is, met een callout onder Normuitleg. De koppenstructuur blijft staan zodat redacteuren de skeletten kunnen invullen.

### Navigatie: de sectiebalk van het thema aangezet

Het thema levert een tweede navigatiebalk die per sectie de onderliggende pagina's uitklapt; dit project gebruikte die niet. Vanaf een normpagina was de enige weg naar een andere norm: terug naar de index, of vorige/volgende. Nu staan alle acht normen in een uitgeklapt paneel, met de huidige pagina gemarkeerd.

**Let op — dit is de enige wijziging met een zichtbaar nadeel:** de breadcrumb verdwijnt. Dat is bewust gedrag van het thema (de breadcrumb slaat de niveaus over die de sectiebalk al toont, en bij een maximale diepte van twee blijft er niets over). Wil je de breadcrumb houden, dan is `bfcf848` los te laten vallen; de rest van de PR staat er niet van afhankelijk.

### Verder

- Inhoudsopgave op normpagina's gaat nu tot voorschriftniveau, met dezelfde paginabrede nummering als de body (geverifieerd: TOC-labels identiek aan de body-koppen, alle ankers bestaan).
- Zoekfilters per sectie in de modal.
- `robots.txt` verwijst naar de sitemap; eigen 404 met de vier ingangen.
- Bollendiagram had `role="img"`, waardoor hulpsoftware de acht normlinks erin niet aanbood → `role="group"`. "Gecontroleerd vernietigen" was op `/samenhang/` alleen via het diagram bereikbaar en staat nu ook in de lopende tekst.
- `/over/doel/`, `/over/doelgroep/` en `/samenhang/` hadden geen enkele uitgaande verwijzing meer.
- Begrippagina's hebben geen inhoudsopgave meer (die bevatte één regel).
- Elk begrip heeft een `weight` die de alfabetische rang volgt, zodat de A-Z index (sorteert op titel) en de carousel (theme page-nav, sorteert op weight) niet uit elkaar kunnen lopen.
- Dood `show_referenties` uit de normen-cascade en het inerte `synoniemen`-veld uit de zoekindex.
- Taxonomieën uitgezet (`/tags/`, `/categories/` waren leeg en stonden in de sitemap).

## Type wijziging

- [x] Bug fix
- [x] Nieuwe feature
- [x] Inhoudelijke correctie (norm-content)
- [ ] Refactor
- [x] Documentatie
- [ ] CI / build / infra

## Test plan

- [x] `python3 scripts/validate-norms.py` — 8 normpagina's geldig
- [x] `pre-commit run --all-files` — alles Passed
- [x] `npm test` — 15/15
- [x] Productiebuild zonder fouten of waarschuwingen
- [x] Linkanalyse op de build: geen kapotte interne links, geen dode ankers, **nul doodlopende pagina's** (was: 9), geen PLACEHOLDER meer in enige pagina, zoekindex of PDF
- [x] A-Z index en de vorige/volgende-carousel van de begrippen lopen in exact dezelfde volgorde
- [x] Sectiebalk: op elke pagina het juiste paneel open met de huidige pagina gemarkeerd; `/samenhang/` heeft terecht geen paneel (geen onderliggende pagina's)
- [ ] Handmatig op de preview: de sectiebalk op desktop en mobiel, de langere inhoudsopgave op norm 1, en het bollendiagram met toetsenbord en screenreader

De laatste stap vraagt een browser en hulpsoftware — die kan ik hier niet draaien.

## Bekend punt bij mergen

Deze PR en [#55](https://github.com/RijksICTGilde/toetsingskader-archiefwet/pull/55) raken allebei `hugo.yaml` en `layouts/normen/single.html`. Welke als tweede gemerged wordt, heeft een rebase nodig. Zeg het maar, dan doe ik die.

## Niet opgelost

Het **sectielabel bij een zoekresultaat** (bevinding 19) zit in de zoek-JS van het thema, die alleen titel + fragment rendert. De filters in deze PR maken onderscheid per sectie mogelijk, maar het label bij het resultaat zelf vraagt een theme-wijziging. Voorstel voor `assets/js/search.js` in `hugo-theme-rijksoverheid`, in de `return`-tak die een resultaat opbouwt:

```js
'<span class="search-result-title">' + highlightQuery(item.title, query) + '</span>' +
'<span class="search-result-section">' + escapeHtml(item.section) + '</span>' +
```

`item.section` zit al in de index en wordt al gebruikt voor filteren en prioriteren; alleen het tonen ontbreekt.

## Inhoudelijke afstemming

De "Zie ook"-verwijzingen zijn afgeleid uit bestaande verwijzingen en verzinnen geen nieuwe relaties. De vervangende placeholder-teksten zijn wél nieuwe formuleringen — die graag even langs de inhoudelijke lijn.

## Checklist

- [x] Pre-commit gepasseerd
- [x] Geen breaking changes (URL's ongewijzigd)
- [x] `CHANGELOG.md` bijgewerkt onder `[Unreleased]`
- [ ] Gerelateerde issues gelinkt